### PR TITLE
Add invalidation index for batch invalidation of related items

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ on [`Invalidator.Invalidate`](https://pkg.go.dev/github.com/bool64/cache#Invalid
 a debugging/firefighting tool.
 
 Deleting of multiple related (labeled) items can be done with 
-[`InvalidationIndex`](ttps://pkg.go.dev/github.com/bool64/cache#InvalidationIndex).
+[`InvalidationIndex`](https://pkg.go.dev/github.com/bool64/cache#InvalidationIndex).
 
 [`Len`](https://pkg.go.dev/github.com/bool64/cache#ShardedMap.Len) returns currently available number of entries (
 including expired).

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ appended to `Invalidator.Callbacks` and it will be triggered
 on [`Invalidator.Invalidate`](https://pkg.go.dev/github.com/bool64/cache#Invalidator.Invalidate). This may be useful as
 a debugging/firefighting tool.
 
+Deleting of multiple related (labeled) items can be done with 
+[`InvalidationIndex`](ttps://pkg.go.dev/github.com/bool64/cache#InvalidationIndex).
+
 [`Len`](https://pkg.go.dev/github.com/bool64/cache#ShardedMap.Len) returns currently available number of entries (
 including expired).
 

--- a/_benchmark/bench_test.go
+++ b/_benchmark/bench_test.go
@@ -1,10 +1,11 @@
 package benchmark_test
 
 import (
-	"benchmark"
 	"encoding"
 	"runtime"
 	"testing"
+
+	"benchmark"
 
 	"github.com/bool64/cache"
 	"github.com/bool64/cache/bench"

--- a/invalidator.go
+++ b/invalidator.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -44,4 +45,99 @@ func (i *Invalidator) Invalidate(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// InvalidationIndex keeps index of keys labeled for future invalidation.
+type InvalidationIndex struct {
+	deleter Deleter
+
+	mu          sync.Mutex
+	labeledKeys map[string][]string
+}
+
+// NewInvalidationIndex creates new instance of label-based invalidator.
+func NewInvalidationIndex(deleter Deleter) *InvalidationIndex {
+	return &InvalidationIndex{
+		deleter:     deleter,
+		labeledKeys: make(map[string][]string),
+	}
+}
+
+// AddInvalidationLabels registers invalidation labels to a cache key.
+func (i *InvalidationIndex) AddInvalidationLabels(key []byte, labels ...string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	ks := string(key)
+	for _, label := range labels {
+		i.labeledKeys[label] = append(i.labeledKeys[label], ks)
+	}
+}
+
+// InvalidateByLabels deletes keys from cache that have any of provided labels and returns number of deleted entries.
+// If delete fails, function puts unprocessed keys back in the index and returns.
+func (i *InvalidationIndex) InvalidateByLabels(ctx context.Context, labels ...string) (int, error) {
+	cutKeys := i.cutKeys(labels...)
+	deleted := make(map[string]bool) // Deduplication index to avoid multiple deletes for keys with multiple labels.
+
+	defer func() {
+		// Return unprocessed keys back.
+		if len(cutKeys) > 0 {
+			i.mu.Lock()
+			defer i.mu.Unlock()
+
+			for label, keys := range cutKeys {
+				// Cut keys already deleted in other labels.
+				for j, k := range keys {
+					if deleted[k] {
+						keys[j] = keys[len(keys)-1]
+						keys = keys[:len(keys)-1]
+					}
+				}
+
+				i.labeledKeys[label] = append(i.labeledKeys[label], keys...)
+			}
+		}
+	}()
+
+	cnt := 0
+
+	for _, label := range labels {
+		for _, k := range cutKeys[label] {
+			if deleted[k] {
+				continue
+			}
+
+			err := i.deleter.Delete(ctx, []byte(k))
+			if err != nil {
+				if errors.Is(err, ErrNotFound) {
+					continue
+				}
+
+				return cnt, err
+			}
+
+			deleted[k] = true
+
+			cnt++
+		}
+
+		delete(cutKeys, label)
+	}
+
+	return cnt, nil
+}
+
+func (i *InvalidationIndex) cutKeys(labels ...string) map[string][]string {
+	res := make(map[string][]string, len(labels))
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	for _, label := range labels {
+		res[label] = i.labeledKeys[label]
+		delete(i.labeledKeys, label)
+	}
+
+	return res
 }

--- a/sharded_map.go
+++ b/sharded_map.go
@@ -33,6 +33,8 @@ type ShardedMap struct {
 }
 
 type shardedMap struct {
+	*InvalidationIndex
+
 	hashedBuckets [shards]hashedBucket
 
 	t *Trait
@@ -65,6 +67,8 @@ func NewShardedMap(options ...func(cfg *Config)) *ShardedMap {
 		t.Len = c.Len
 		t.Evict = evict
 	})
+
+	c.InvalidationIndex = NewInvalidationIndex(c)
 
 	runtime.SetFinalizer(C, func(m *ShardedMap) {
 		close(m.t.Closed)

--- a/sharded_map_go1.18.go
+++ b/sharded_map_go1.18.go
@@ -35,6 +35,8 @@ type hashedBucketOf[V any] struct {
 }
 
 type shardedMapOf[V any] struct {
+	*InvalidationIndex
+
 	hashedBuckets [shards]hashedBucketOf[V]
 
 	t *TraitOf[V]
@@ -67,6 +69,8 @@ func NewShardedMapOf[V any](options ...func(cfg *Config)) *ShardedMapOf[V] {
 		t.Len = c.Len
 		t.Evict = evict
 	})
+
+	c.InvalidationIndex = NewInvalidationIndex(c)
 
 	runtime.SetFinalizer(C, func(m *ShardedMapOf[V]) {
 		close(m.t.Closed)

--- a/sync_map.go
+++ b/sync_map.go
@@ -24,6 +24,8 @@ type SyncMap struct {
 }
 
 type syncMap struct {
+	*InvalidationIndex
+
 	data sync.Map
 
 	t *Trait
@@ -52,6 +54,8 @@ func NewSyncMap(options ...func(cfg *Config)) *SyncMap {
 		t.Len = c.Len
 		t.Evict = evict
 	})
+
+	c.InvalidationIndex = NewInvalidationIndex(c)
 
 	runtime.SetFinalizer(C, func(m *SyncMap) {
 		close(m.t.Closed)


### PR DESCRIPTION
This PR adds a way to track and invalidate related cache entries using label index.
This can be handy in case of invalidation policies that should affect multiple cached items at once. 

```go
	c := cache.NewShardedMap()
	ctx := context.TODO()

	// Any cache key can be accompanied by invalidation labels.
	_ = c.Write(ctx, []byte("my-foo"), "foo")
	c.AddInvalidationLabels([]byte("my-foo"), "my", "f**")

	_ = c.Write(ctx, []byte("my-bar"), "bar")
	c.AddInvalidationLabels([]byte("my-bar"), "my", "b**")

	_ = c.Write(ctx, []byte("my-baz"), "baz")
	c.AddInvalidationLabels([]byte("my-baz"), "my", "b**")

	n, _ := c.InvalidateByLabels(ctx, "b**")

	fmt.Println("deleted items for 'b**':", n)

	_, err := c.Read(ctx, []byte("my-foo"))
	fmt.Println("my-foo err:", err)

	_, err = c.Read(ctx, []byte("my-bar"))
	fmt.Println("my-bar err:", err)

	_, err = c.Read(ctx, []byte("my-baz"))
	fmt.Println("my-baz err:", err)

	n, _ = c.InvalidateByLabels(ctx, "my", "f**")

	fmt.Println("deleted items for 'my':", n)

	_, err = c.Read(ctx, []byte("my-foo"))
	fmt.Println("my-foo err:", err)

	// Output:
	// deleted items for 'b**': 2
	// my-foo err: <nil>
	// my-bar err: missing cache item
	// my-baz err: missing cache item
	// deleted items for 'my': 1
	// my-foo err: missing cache item
```