### PR TITLE
Make CountSoftLimit more aggressive to reach the threshold in a single run

### DIFF
--- a/config.go
+++ b/config.go
@@ -45,6 +45,8 @@ type Config struct {
 	SysMemSoftLimit uint64
 
 	// CountSoftLimit sets count threshold when eviction will be triggered.
+	// As opposed to memory soft limits, when count limit is exceeded, eviction will remove items to achieve
+	// the level of CountSoftLimit*(1-EvictFraction), which may be more items that EvictFraction defines.
 	CountSoftLimit uint64
 
 	// EvictFraction is a fraction (0, 1] of total count of items to be evicted when resource is overused,

--- a/evict_go1.18_test.go
+++ b/evict_go1.18_test.go
@@ -228,14 +228,14 @@ func Test_generic_LFU_eviction(t *testing.T) {
 
 			assert.LessOrEqual(t, c.Len(), 51)
 
-			for i := 0; i < 51; i++ {
+			for i := 0; i < 50; i++ {
 				k := []byte(strconv.Itoa(i))
 
 				_, err := c.Read(ctx, k)
 				require.NoError(t, err, i)
 			}
 
-			for i := 51; i < 100; i++ {
+			for i := 50; i < 100; i++ {
 				k := []byte(strconv.Itoa(i))
 
 				_, err := c.Read(ctx, k)
@@ -279,16 +279,16 @@ func Test_generic_LRU_eviction(t *testing.T) {
 				require.Less(t, i, 10, c.Len())
 			}
 
-			assert.LessOrEqual(t, c.Len(), 51)
+			assert.Equal(t, c.Len(), 50)
 
-			for i := 0; i < 49; i++ {
+			for i := 0; i < 50; i++ {
 				k := []byte(strconv.Itoa(i))
 				_, err := c.Read(ctx, k)
 
 				require.EqualError(t, err, "missing cache item", i) // Evicted.
 			}
 
-			for i := 49; i < 100; i++ {
+			for i := 50; i < 100; i++ {
 				k := []byte(strconv.Itoa(i))
 				_, err := c.Read(ctx, k)
 

--- a/evict_test.go
+++ b/evict_test.go
@@ -34,6 +34,7 @@ type evictInterface interface {
 	ReadWriter
 	Len() int
 	evictMostExpired(evictFraction float64) int
+	evictLeastCounter(evictFraction float64) int
 }
 
 func TestShardedMap_evictHeapInuse(t *testing.T) {
@@ -224,16 +225,17 @@ func Test_LFU_eviction(t *testing.T) {
 				require.Less(t, i, 10, c.Len())
 			}
 
-			assert.LessOrEqual(t, c.Len(), 51)
+			cnt := c.Len()
+			assert.Equal(t, cnt, 50)
 
-			for i := 0; i < 51; i++ {
+			for i := 0; i < 50; i++ {
 				k := []byte(strconv.Itoa(i))
 
 				_, err := c.Read(ctx, k)
 				require.NoError(t, err, i)
 			}
 
-			for i := 51; i < 100; i++ {
+			for i := 50; i < 100; i++ {
 				k := []byte(strconv.Itoa(i))
 
 				_, err := c.Read(ctx, k)
@@ -286,7 +288,7 @@ func Test_LRU_eviction(t *testing.T) {
 				require.EqualError(t, err, "missing cache item", i) // Evicted.
 			}
 
-			for i := 49; i < 100; i++ {
+			for i := 50; i < 100; i++ {
 				k := []byte(strconv.Itoa(i))
 				_, err := c.Read(ctx, k)
 


### PR DESCRIPTION
The logic of applying `EvictFraction` to current count fits well to memory limits, where it is impossible to have precise expectations. However, for count limit, it is possible to set a precise target expectation within a single iteration.