### PR TITLE
Bug fix for sharded_map_go1.18.go Load method 

### DIFF
--- a/sharded_map_go1.18.go
+++ b/sharded_map_go1.18.go
@@ -85,10 +85,10 @@ func NewShardedMapOf[V any](options ...func(cfg *Config)) *ShardedMapOf[V] {
 func (c *shardedMapOf[V]) Load(key []byte) (val V, loaded bool) {
 	v, err := c.Read(bgCtx, key)
 	if err != nil {
-		return val, true
+		return val, false
 	}
 
-	return v, false
+	return v, true
 }
 
 // Store sets the value for a key.

--- a/sharded_map_go1.18_test.go
+++ b/sharded_map_go1.18_test.go
@@ -108,3 +108,21 @@ cache_hit{name="test"} 1
 cache_items{name="test"} 0
 cache_write{name="test"} 1`, st.Metrics())
 }
+
+func TestNewShardedMapOf_Load_Store(t *testing.T) {
+	logger := ctxd.LoggerMock{}
+	st := stats.TrackerMock{}
+
+	c := cache.NewShardedMapOf[string](func(config *cache.Config) {
+		config.Logger = &logger
+		config.Stats = &st
+		config.Name = "test"
+		config.TimeToLive = time.Hour
+	})
+
+	c.Store([]byte("foo"), "bar")
+	v, loaded := c.Load([]byte("foo"))
+	assert.True(t, loaded)
+	assert.Equal(t, "bar", v)
+	assert.Equal(t, 1, c.Len())
+}


### PR DESCRIPTION
Load method in sharded_map_go1.18.go returns loaded=true when there is an error and loaded=false when the value is actually loaded. 

This PR fixes this bug.