### PR TITLE
Add blob abstraction and filecache

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,67 @@ If `ObserveMutability` is enabled, `Failover` will also emit stats of how often 
 previous. This may help to understand data volatility and come up with a better TTL value. The check is done
 with [`reflect.DeepEqual`](https://pkg.go.dev/reflect#DeepEqual) and may affect performance.
 
+## Blob Cache
+
+For streamed file/blob workloads, the library also provides a blob-oriented abstraction and a local filesystem-backed
+storage implementation.
+
+[`blob.Entry`](https://pkg.go.dev/github.com/bool64/cache/blob#Entry) is a reopenable descriptor of content:
+
+```go
+type Entry interface {
+    Meta() Meta
+    Open() (io.ReadCloser, error)
+}
+```
+
+This keeps the cached value stable while letting callers open a fresh reader on demand.
+
+[`filecache.Storage`](https://pkg.go.dev/github.com/bool64/cache/filecache#Storage) implements
+[`cache.ReadWriterOf[blob.Entry]`](https://pkg.go.dev/github.com/bool64/cache#ReadWriterOf) and persists immutable blob
+files on local disk together with a compact in-memory index snapshot.
+
+Blob sources can be created with helpers from the [`blob`](https://pkg.go.dev/github.com/bool64/cache/blob) package,
+for example:
+
+* [`blob.FromReader`](https://pkg.go.dev/github.com/bool64/cache/blob#FromReader)
+* [`blob.FromReadCloser`](https://pkg.go.dev/github.com/bool64/cache/blob#FromReadCloser)
+* [`blob.FromHTTPResponse`](https://pkg.go.dev/github.com/bool64/cache/blob#FromHTTPResponse)
+
+Failover works with blob entries as well:
+
+```go
+storage, _ := filecache.NewStorage("/var/cache/photos")
+
+f := cache.NewFailoverOf[blob.Entry](func(cfg *cache.FailoverConfigOf[blob.Entry]) {
+    cfg.Backend = storage
+})
+
+entry, err := f.Get(ctx, []byte("photo:1"), func(ctx context.Context) (blob.Entry, error) {
+    resp, err := http.Get("https://example.com/photo.jpg")
+    if err != nil {
+        return nil, err
+    }
+
+    return blob.FromHTTPResponse(resp), nil
+})
+if err != nil {
+    return err
+}
+
+rc, err := entry.Open()
+if err != nil {
+    return err
+}
+defer rc.Close()
+
+// Use rc directly, or type assert to io.ReadSeeker if the backend provides it.
+```
+
+The local file-backed implementation currently requires explicit
+[`Storage.Close()`](https://pkg.go.dev/github.com/bool64/cache/filecache#Storage.Close) to flush the index snapshot on
+application shutdown.
+
 ## Sharded Map
 
 [`ShardedMap`](https://pkg.go.dev/github.com/bool64/cache#ShardedMap)

--- a/blob/DESIGN.md
+++ b/blob/DESIGN.md
@@ -1,0 +1,613 @@
+# Blob Cache Design
+
+## Status
+
+This document captures the current design direction for a blob-oriented cache ecosystem.
+
+The goal is to preserve context across sessions and evolve this document as the design becomes more concrete.
+
+## Motivation
+
+The main use case is serving photos or other files in an HTTP service.
+
+Typical flow:
+
+1. A request needs a file identified by cache key.
+2. On cache miss or stale entry, the cache downloads the file from an origin server.
+3. The cache stores file content in local persistent storage.
+4. The cache returns an object usable by HTTP-serving code without loading the whole file into memory.
+
+Important requirements:
+
+- persistent local-file-backed cache
+- in-memory lightweight index of entries
+- janitor behavior similar to existing in-memory cache
+- compatibility with failover/stale serving behavior
+- support for preserving relevant HTTP response metadata
+- no requirement to materialize full file content into `[]byte`
+
+## Package Direction
+
+Current preference is to split responsibilities like this:
+
+- `cache`
+  - generic cache primitives such as `FailoverOf[T]`, `ReadWriterOf[T]`, `ShardedMapOf[T]`
+- `blob`
+  - generic blob abstractions and helper constructors
+- `filecache`
+  - local filesystem-backed implementation of `cache.ReadWriterOf[blob.Entry]`
+- `sqlcache`
+  - SQL/DB-backed implementation of `cache.ReadWriterOf[blob.Entry]`
+
+Rationale:
+
+- keeps root `cache` package generic
+- gives blob abstractions a backend-neutral home
+- gives helper constructors such as HTTP-response adapters a natural home
+- avoids making blob abstractions look local-file-specific when they are also useful for DB/S3/custom storage
+
+## Core Object Model
+
+Current preferred exported names:
+
+- `blob.Entry`
+- `blob.Meta`
+
+### `Meta`
+
+`Meta` carries content metadata that should travel with the object.
+
+Likely fields:
+
+```go
+type Meta struct {
+	Name    string
+	Size    int64
+	ModTime time.Time
+	Extra   any
+}
+```
+
+Notes:
+
+- `Name`, `Size`, and `ModTime` are considered common fields for arbitrary blob-like content.
+- Domain-specific metadata should live in `Extra`.
+- `Extra any` is preferred over `map[string]any` because it allows callers to pass typed payloads.
+- For HTTP-oriented usage, `Extra` can hold a typed struct with response status/headers.
+- Opaque `Extra` data is expected to be round-tripped by storage/index implementations.
+
+Example of HTTP-oriented extension payload:
+
+```go
+type HTTPExtra struct {
+	StatusCode int
+	Header     http.Header
+}
+```
+
+### `Entry`
+
+Current preferred shape:
+
+```go
+type Entry interface {
+	Meta() Meta
+	Open() (io.ReadCloser, error)
+}
+```
+
+Rationale:
+
+- this is the stable value to keep inside `FailoverOf` and cache backends
+- it is compact and durable
+- it can live inside `ShardedMapBy[K, blob.Entry]` or any `ReadWriterOf[blob.Entry]`
+- it separates cached value identity from ephemeral opened handles
+- it avoids forcing all blob backends to expose the same advanced reader capabilities
+
+Important distinction:
+
+- `Entry` is the cached descriptor/reference
+- the result of `Open()` is the opened stream handle
+
+This distinction is now the key mechanism for reusing existing cache primitives safely.
+
+## Two Kinds of Entry Implementations
+
+The same `blob.Entry` abstraction is expected to have two distinct implementation classes.
+
+### 1. Transient source entry
+
+Example source:
+
+- `blob.FromHTTPResponse(resp)`
+
+This entry is produced by the builder callback and wraps origin content.
+
+Expected behavior:
+
+- `Meta()` works
+- `Open()` returns a readable and closable source
+- advanced capabilities such as `Seek` and `ReadAt` may be absent
+
+Typical implementations:
+
+- response-backed source entry
+- reader-backed source entry
+
+### 2. Stored entry
+
+This entry is returned from cache storage and knows how to open a durable blob.
+
+Expected behavior:
+
+- `Meta()` works
+- `Open()` returns a readable and closable handle
+- richer capabilities may be present depending on storage/backend
+
+Typical implementations:
+
+- local-file-backed entry opening `*os.File`
+- DB-backed entry opening a DB/blob reader
+- object-storage-backed entry opening a network or buffered reader
+
+## Capability Diversity Across Storages
+
+Different blob storages may offer different capabilities.
+
+Examples:
+
+- local file: `Reader`, `ReaderAt`, `Seeker`, `Closer`
+- HTTP response body: `Reader`, `Closer`
+- database blob: often `Reader`, sometimes random access depending on driver
+- S3 object: stream by default, random access may require range requests or buffering
+
+Important conclusion:
+
+- absence of `Seek` is not necessarily a deal-breaker for the overall design
+
+Reasoning:
+
+- some user code can work around missing seekability in userland
+- for example by reading all content and wrapping it with `bytes.NewReader`
+- this has a resource cost, but it preserves compatibility when random access is needed
+
+Current stance:
+
+- `blob.Entry.Open()` returns `io.ReadCloser`
+- concrete returned readers may also implement `io.Seeker`, `io.ReaderAt`, or both
+- consumers that need those capabilities can use type assertions
+- storage implementations are free to expose richer capabilities when practical
+- implementations should avoid wrappers like `io.NopCloser` when they would hide useful reader interfaces
+- capability-preserving wrappers are preferred when a close method must be added to a richer reader
+
+This keeps the API simple while avoiding the assumption that all backends are naturally file-like.
+
+## Construction Helpers
+
+Current preferred helper names:
+
+- `blob.FromHTTPResponse(resp)`
+- `blob.FromReader(r, meta)`
+
+Likely additional helpers:
+
+- `blob.FromReadCloser(rc, meta)`
+- maybe `blob.FromFile(f, meta)`
+
+Meaning of these constructors:
+
+- they produce ingestible transient `blob.Entry` values
+- cache manager/storage reads bytes from `Open()` and persists the result into durable storage
+- they are not necessarily the final entry form returned to users
+
+## Failover Integration
+
+The strongest current direction is to maximize reuse of existing `cache.FailoverOf` and `ReadWriterOf`.
+
+The key observation is:
+
+- `FailoverOf` expects a stable cached value
+- opened file/blob handles are not stable cached values
+- `blob.Entry` is the right stable cached value
+
+Therefore the file/blob cache layer should likely be built around:
+
+- `FailoverOf[blob.Entry]`
+- `ReadWriterOf[blob.Entry]`
+
+instead of:
+
+- `FailoverOf[io.ReadCloser]`
+
+This avoids duplicating failover logic and lets the existing cache backends participate.
+
+Desired usage shape:
+
+```go
+	entry, err := fc.Get(ctx, key, func(ctx context.Context) (blob.Entry, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	return blob.FromHTTPResponse(resp), nil
+})
+```
+
+Important intended property:
+
+- the cache instance should conceptually match a `FailoverOf`-style interface
+
+Meaning:
+
+- one build callback per key on miss/stale refresh
+- stale serving behavior similar to current failover cache
+- result type inside failover/cache storage is `blob.Entry`
+- the caller then opens an `Object` from the entry
+
+Potential thin wrapper:
+
+- a higher-level helper could still expose `Get(...)(io.ReadCloser, Meta, error)` or a similar convenience API by internally calling `entry.Open()`
+- but the reusable primitive should be `blob.Entry`
+
+## Why `FailoverOf[io.ReadCloser]` Is A Bad Fit
+
+This point was clarified during design discussion.
+
+If `io.ReadCloser` were used as the `V` in `FailoverOf[V]`, current `FailoverOf` behavior would become problematic because:
+
+- `backend.Read` returns an opened, stateful handle
+- stale refresh reuses that returned value and calls `backend.Write(..., val)`
+- `Write` would need to consume `Read` from the passed object to persist it
+- consuming the stream would mutate or exhaust the same object later returned to the caller
+
+This is acceptable for immutable value objects, but not for open stream handles.
+
+That is the main reason `blob.Entry` is now preferred as the cached value.
+
+## Storage Write Semantics
+
+When `ReadWriterOf[blob.Entry].Write(ctx, key, entry)` is invoked for a storage-backed implementation, the expected behavior is:
+
+1. call `entry.Open()`
+2. get an `io.ReadCloser`
+3. stream bytes from the object's reader into durable storage
+4. persist associated metadata / locator
+5. close the transient source object
+6. store and later return a compact stored `blob.Entry`
+
+For local filesystem storage, this likely means:
+
+1. open source object
+2. write to a temp file such as `./storage/<derived>.tmp`
+3. atomically rename to `./storage/<derived>.dat`
+4. store a `blob.Entry` that knows how to reopen that file
+
+This general pattern also works for other backends such as DB or object storage.
+
+## Storage Implementations
+
+### `filecache.Storage`
+
+Current direction:
+
+- `filecache.Storage` implements `cache.ReadWriterOf[blob.Entry]`
+- `filecache.NewStorage(path string)` creates an internal hot index, likely `cache.ShardedMapOf[blob.Entry]`
+- if an index file exists on startup, it is restored into that internal map
+- `Read` serves from the in-memory descriptor index
+- `Write` materializes incoming entry data into local files and updates the index
+- `Close()` is required and should dump the in-memory index back to disk
+
+`Close()` is necessary because finalizers are not reliable during application shutdown.
+
+This dump/restore approach is considered suitable for local filesystem storage.
+
+### `sqlcache.BlobStorage`
+
+Current direction:
+
+- `sqlcache.BlobStorage` implements `cache.ReadWriterOf[blob.Entry]`
+- `Read` performs a `SELECT`
+- `Write` performs an `INSERT/UPDATE` or equivalent
+- the DB itself serves as durable storage for index metadata and possibly blob content
+- no dump/restore step is required
+
+Important note:
+
+- a SQL-backed implementation may be shared by multiple application instances
+- local per-process `FailoverOf` locking does not become distributed locking automatically
+- shared storage may improve hit ratio across instances but does not by itself eliminate cross-instance duplicate rebuilds
+- cluster-wide stampede prevention is explicitly out of scope for the initial design
+
+## `filecache` Internal State Model
+
+`filecache` should keep two kinds of state.
+
+### 1. Persistent entry state
+
+This is the value stored in the internal `cache.ShardedMapOf[blob.Entry]` index and dumped/restored on disk.
+
+Likely shape:
+
+```go
+type entry struct {
+	meta    blob.Meta
+	version string
+	path    string
+}
+```
+
+Purpose:
+
+- enough information to reopen the current blob after restart
+- compact enough to stay in the in-memory descriptor index
+
+### 2. Ephemeral runtime state
+
+This state is process-local and must not be persisted.
+
+Likely shape:
+
+```go
+type runtimeFile struct {
+	path string
+	refs int64
+	dead bool
+}
+```
+
+It should live in a plain mutex-protected map inside `filecache.Storage`.
+
+Rationale:
+
+- the operations guarded by this map are slow file operations anyway
+- open/close/version-swap frequency does not justify a more complex structure
+- this state is only needed for runtime refcounting and garbage collection
+
+Likely owner state:
+
+```go
+type Storage struct {
+	index *cache.ShardedMapOf[blob.Entry]
+
+	mu      sync.Mutex
+	runtime map[string]*runtimeFile
+}
+```
+
+Where the map key is likely `version` or a version-derived path.
+
+## Concurrency Model
+
+If multiple callers request the same key concurrently:
+
+1. At most one build should run for that key.
+2. Persisted content should be stored once.
+3. Each caller should receive its own independently opened stored reader.
+
+Important invariant:
+
+- callers must not share the same `*os.File` handle
+
+Reason:
+
+- reader state is mutable
+- `Seek` state may be mutable when supported
+- callers may read concurrently
+- each request needs an isolated handle
+
+So even if one cached entry points to one persisted blob/file, each `blob.Entry.Open()` should create a fresh opened reader.
+
+## Versioning And Garbage Collection
+
+Current preferred strategy:
+
+- every successful `Write` creates a new immutable versioned file
+- the index atomically switches to the new current version
+- the previous version becomes garbage immediately after index swap
+- each `Open()` increments a runtime refcount for that version
+- each returned reader wrapper decrements that refcount on `Close()`
+- if a version is marked garbage and its refcount drops to zero, it should be deleted immediately
+
+This gives prompt cleanup without relying on platform-specific behavior of deleting open files.
+
+Janitor remains useful as fallback/reconciliation:
+
+- clean orphaned files left after crashes
+- clean leaked temp files
+- reconcile disk contents with current index state
+
+`Close()` should also run a best-effort final sweep.
+
+## Close Semantics
+
+Current preference:
+
+- users must call `Close()` on readers returned by `Open()`
+
+Reasoning:
+
+- returned stored objects are expected to hold OS resources
+- this matches standard `os.File` usage
+- this enables direct use with `http.ServeContent`
+
+Typical handler shape:
+
+```go
+entry, err := fc.Get(...)
+if err != nil {
+	return err
+}
+
+rc, err := entry.Open()
+if err != nil {
+	return err
+}
+defer rc.Close()
+
+if rs, ok := rc.(io.ReadSeeker); ok {
+	http.ServeContent(w, r, entry.Meta().Name, entry.Meta().ModTime, rs)
+}
+```
+
+Alternative considered but not chosen yet:
+
+- return a metadata object with `Open()`
+
+That may still be reconsidered later if resource-lifetime ergonomics become a concern.
+
+## Persistent Storage Model
+
+Initial focus remains local filesystem storage, but index durability is now considered backend-specific rather than universal.
+
+For local filesystem storage:
+
+- cache content is stored as files on disk
+- an in-memory metadata index may be loaded on creation
+- that index may be dumped on close
+- janitor removes expired/evicted data files together with index entries
+- configurable nested directory levels based on leading characters of generated file names remain relevant
+- immutable versioned file names are preferred over in-place overwrites
+
+For DB-backed storage:
+
+- the DB can serve as durable blob store and durable index
+- dump/restore of an in-memory index is not necessary
+- an in-memory cache may still exist as an optimization, but not as the source of truth
+
+## HTTP Metadata Preservation
+
+The origin response may contain useful metadata that should survive caching.
+
+Examples:
+
+- `Content-Type`
+- `Content-Length`
+- `ETag`
+- `Last-Modified`
+- `Cache-Control`
+- `Content-Disposition`
+
+Current leaning:
+
+- place HTTP-specific values into a typed `Meta.Extra` payload
+- store and reload that payload with the entry
+- let serving code interpret/filter them when replaying them
+- for `filecache`, any `Meta.Extra` payload used with dump/restore must be gob-compatible
+- this gob requirement is a `filecache` implementation detail, not a `blob` package contract
+
+Example:
+
+```go
+type HTTPExtra struct {
+	StatusCode int
+	Header     http.Header
+}
+```
+
+## Why Not Use Existing Value-Oriented Cache API
+
+Using existing `Read(ctx, key) -> interface{}` style APIs is considered a poor fit for this use case.
+
+Reasoning:
+
+- file serving should not require loading whole content into memory
+- file objects are stream-oriented and resource-owning
+- persistent file-backed semantics differ from current in-memory value cache semantics
+
+Therefore current direction is:
+
+- separate package
+- file/blob-oriented API
+- maximize reuse of existing root cache interfaces by storing `blob.Entry` values inside them
+- avoid duplicating failover logic where `FailoverOf[blob.Entry]` is sufficient
+
+## Generalization Beyond Local Files
+
+There is interest in making the design extensible to other storage backends such as S3 or custom stores.
+
+This is now a more central design goal.
+
+The current direction is:
+
+- treat the cached value as backend-neutral `blob.Entry`
+- let different storage implementations define concrete `blob.Entry` forms
+- integrate those entries with existing cache backends such as `ShardedMapBy[K, blob.Entry]`
+
+Conceptually:
+
+1. builder returns a transient entry
+2. storage-specific `Write` persists it
+3. cached backend stores a compact `blob.Entry`
+4. callers open fresh readers from that entry
+
+This would allow:
+
+- local filesystem backend
+- S3-backed backend
+- DB-backed blob backend
+- custom user-defined backends
+
+Open concern:
+
+- some backends do not naturally support `Seek` and `ReadAt`
+- the core API does not require them
+- some backends may expose them via concrete return types from `Open()`
+- some backends may emulate them with extra buffering or range requests
+- userland may choose to wrap content with `bytes.NewReader` when random access is required
+- this flexibility is acceptable even at some performance/resource cost
+
+## Relation To Existing Sharded Map
+
+Earlier implementation attempt duplicated a dedicated sharded metadata map for file cache.
+
+Better direction identified during discussion:
+
+- keep the in-memory part lightweight and close to existing `ShardedMap`
+- reuse `ShardedMapBy[K, blob.Entry]` or other existing `ReadWriterOf[blob.Entry]` implementations where possible
+- only add hooks/extensions if storage coordination cannot be expressed cleanly in `Read`/`Write`
+
+Rationale:
+
+- reuse proven in-memory indexing behavior
+- reuse janitor/eviction behavior where possible
+- avoid maintaining parallel sharded-index logic
+- let `blob.Entry` be the compact index resident in memory/cache backends
+
+This area remains open for implementation design.
+
+## Open Questions
+
+At this point, architectural questions are mostly settled.
+
+The remaining choices are implementation details that can be decided during coding:
+
+1. exact internal entry/runtime struct layouts in `filecache`
+2. exact version id and path naming scheme
+3. exact startup reconciliation logic for orphaned files and temp files
+4. exact `Close()` sequencing for dump, janitor stop, and final sweep
+5. exact helper set to add later for ergonomic `io.ReadSeeker` opening/fallbacks
+
+## Current Preferred Direction Summary
+
+At this point the preferred design is:
+
+- introduce a dedicated `blob` package
+- use `blob.Entry` and `blob.Meta`
+- support helpers such as `blob.FromHTTPResponse(resp)` and `blob.FromReader(r, meta)`
+- make `Meta` contain common fields plus `Extra any`
+- make the stable cached value be `blob.Entry`
+- maximize reuse of `cache.FailoverOf[blob.Entry]` and `ReadWriterOf[blob.Entry]`
+- treat origin-backed response objects as transient ingest sources
+- let storage-backed `Write` materialize transient sources into durable blobs
+- make `blob.Entry.Open()` return `io.ReadCloser`
+- let concrete opened readers optionally expose richer interfaces such as `io.Seeker` and `io.ReaderAt`
+- require users to `Close()` returned readers
+- implement storage backends such as `filecache.Storage` and `sqlcache.BlobStorage`
+- reuse existing cache backends such as `ShardedMapBy[K, blob.Entry]` wherever possible
+- support various blob storages including local files, DB blobs, S3-like stores, and custom user implementations
+- for `filecache`, use immutable versioned files plus runtime refcount-based garbage collection
+- keep runtime refcount/dead-file state in a plain mutex-protected map inside `filecache.Storage`
+- make `filecache.Storage.Close()` explicit and required
+- keep checksum/hash standardization out of the public API for now and, if needed, represent such details inside `Meta.Extra` or backend-private state
+- for now, make storage `Write` always rewrite/materialize incoming content rather than trying to short-circuit reuse

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -1,0 +1,139 @@
+// Package blob defines reopenable blob descriptors and helper constructors
+// that can be cached with cache.ReadWriterOf or cache.FailoverOf.
+package blob
+
+import (
+	"encoding/gob"
+	"io"
+	"net/http"
+	"path"
+	"sync"
+	"time"
+)
+
+// Meta describes a blob.
+type Meta struct {
+	Name    string
+	Size    int64
+	ModTime time.Time
+	Extra   any
+}
+
+// Entry is a reopenable descriptor of a blob.
+type Entry interface {
+	Meta() Meta
+	Open() (io.ReadCloser, error)
+}
+
+// HTTPExtra is a conventional HTTP response payload for Meta.Extra.
+type HTTPExtra struct {
+	StatusCode int
+	Header     http.Header
+}
+
+//nolint:gochecknoinits // Gob registration must happen at package init time for filecache dump/restore.
+func init() {
+	gob.Register(HTTPExtra{})
+}
+
+type transientEntry struct {
+	meta Meta
+	open func() (io.ReadCloser, error)
+}
+
+// Meta returns blob metadata.
+func (t transientEntry) Meta() Meta {
+	return t.meta
+}
+
+// Open opens the underlying reader.
+func (t transientEntry) Open() (io.ReadCloser, error) {
+	return t.open()
+}
+
+// FromReader creates a transient entry from an io.Reader.
+func FromReader(r io.Reader, meta Meta) Entry {
+	return FromReadCloser(readCloser{Reader: r}, meta)
+}
+
+// FromReadCloser creates a transient entry from an io.ReadCloser.
+func FromReadCloser(rc io.ReadCloser, meta Meta) Entry {
+	var (
+		mu     sync.Mutex
+		opened bool
+	)
+
+	return transientEntry{
+		meta: meta,
+		open: func() (io.ReadCloser, error) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			if opened {
+				return nil, io.ErrClosedPipe
+			}
+
+			opened = true
+
+			return rc, nil
+		},
+	}
+}
+
+// FromHTTPResponse creates a transient entry backed by an HTTP response body.
+func FromHTTPResponse(resp *http.Response) Entry {
+	meta := Meta{
+		Name:    responseName(resp),
+		Size:    responseSize(resp),
+		ModTime: responseModTime(resp),
+		Extra: HTTPExtra{
+			StatusCode: resp.StatusCode,
+			Header:     resp.Header.Clone(),
+		},
+	}
+
+	return FromReadCloser(resp.Body, meta)
+}
+
+type readCloser struct {
+	io.Reader
+}
+
+func (readCloser) Close() error {
+	return nil
+}
+
+func responseName(resp *http.Response) string {
+	if resp == nil || resp.Request == nil || resp.Request.URL == nil {
+		return ""
+	}
+
+	name := path.Base(resp.Request.URL.Path)
+	if name == "." || name == "/" {
+		return ""
+	}
+
+	return name
+}
+
+func responseSize(resp *http.Response) int64 {
+	if resp == nil || resp.ContentLength < 0 {
+		return 0
+	}
+
+	return resp.ContentLength
+}
+
+func responseModTime(resp *http.Response) time.Time {
+	if resp == nil {
+		return time.Time{}
+	}
+
+	if lastModified := resp.Header.Get("Last-Modified"); lastModified != "" {
+		if t, err := http.ParseTime(lastModified); err == nil {
+			return t
+		}
+	}
+
+	return time.Time{}
+}

--- a/blob/blob_test.go
+++ b/blob/blob_test.go
@@ -1,0 +1,69 @@
+package blob_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/bool64/cache/blob"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromReader(t *testing.T) {
+	entry := blob.FromReader(bytes.NewBufferString("hello"), blob.Meta{Name: "greeting.txt"})
+
+	rc, err := entry.Open()
+	require.NoError(t, err)
+	defer rc.Close()
+
+	b, err := io.ReadAll(rc)
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello", string(b))
+	assert.Equal(t, "greeting.txt", entry.Meta().Name)
+}
+
+func TestFromHTTPResponse(t *testing.T) {
+	reqURL, err := url.Parse("https://example.com/images/photo.jpg")
+	require.NoError(t, err)
+
+	resp := &http.Response{
+		StatusCode:    http.StatusCreated,
+		ContentLength: 5,
+		Header: http.Header{
+			"Last-Modified": []string{"Mon, 02 Jan 2006 15:04:05 GMT"},
+			"Content-Type":  []string{"image/jpeg"},
+		},
+		Body: io.NopCloser(bytes.NewBufferString("image")),
+		Request: &http.Request{
+			URL: reqURL,
+		},
+	}
+
+	entry := blob.FromHTTPResponse(resp)
+
+	meta := entry.Meta()
+	assert.Equal(t, "photo.jpg", meta.Name)
+	assert.Equal(t, int64(5), meta.Size)
+	assert.Equal(t, time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC), meta.ModTime)
+
+	extra, ok := meta.Extra.(blob.HTTPExtra)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusCreated, extra.StatusCode)
+	assert.Equal(t, "image/jpeg", extra.Header.Get("Content-Type"))
+
+	rc, err := entry.Open()
+	require.NoError(t, err)
+	defer rc.Close()
+
+	b, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "image", string(b))
+
+	_, err = entry.Open()
+	assert.ErrorIs(t, err, io.ErrClosedPipe)
+}

--- a/cache.go
+++ b/cache.go
@@ -39,6 +39,11 @@ type ReadWriter interface {
 	Writer
 }
 
+// WriteAndReader allows a backend to store a value and return its stored representation.
+type WriteAndReader interface {
+	WriteAndRead(ctx context.Context, key []byte, value interface{}) (interface{}, error)
+}
+
 // Entry is cache entry with key and value.
 type Entry interface {
 	Key() []byte

--- a/cache_by_go1.18.go
+++ b/cache_by_go1.18.go
@@ -26,6 +26,11 @@ type ReadWriterBy[K comparable, V any] interface {
 	WriterBy[K, V]
 }
 
+// WriteAndReaderBy allows a backend to store a value and return its stored representation.
+type WriteAndReaderBy[K comparable, V any] interface {
+	WriteAndRead(ctx context.Context, key K, value V) (V, error)
+}
+
 // WalkerBy calls function for every entry in cache and fails on first error returned by that function.
 //
 // Count of processed entries is returned.

--- a/cache_go1.18.go
+++ b/cache_go1.18.go
@@ -26,6 +26,11 @@ type ReadWriterOf[V any] interface {
 	WriterOf[V]
 }
 
+// WriteAndReaderOf allows a backend to store a value and return its stored representation.
+type WriteAndReaderOf[V any] interface {
+	WriteAndRead(ctx context.Context, key []byte, value V) (V, error)
+}
+
 // WalkerOf calls function for every entry in cache and fails on first error returned by that function.
 //
 // Count of processed entries is returned.

--- a/config.go
+++ b/config.go
@@ -60,6 +60,9 @@ type Config struct {
 
 	// EvictionStrategy is EvictMostExpired by default.
 	EvictionStrategy EvictionStrategy
+
+	// OnDelete is called when an entry is removed from cache by Delete, DeleteAll, expiration cleanup, or eviction.
+	OnDelete func(key []byte, value interface{})
 }
 
 // EvictionStrategy defines eviction behavior when soft limit is met during cleanup job.

--- a/failover.go
+++ b/failover.go
@@ -74,7 +74,9 @@ type Failover struct {
 	// Errors caches errors of failed updates.
 	Errors *ShardedMap
 
-	backend  ReadWriter
+	backend ReadWriter
+	wr      WriteAndReader
+
 	lock     sync.Mutex     // Securing keyLocks
 	keyLocks map[string]*kl // Preventing update concurrency per key
 	config   FailoverConfig
@@ -115,6 +117,8 @@ func NewFailover(options ...func(cfg *FailoverConfig)) *Failover {
 		cfg.BackendConfig.Stats = cfg.Stats
 		f.backend = NewShardedMap(cfg.BackendConfig.Use)
 	}
+
+	f.wr, _ = f.backend.(WriteAndReader)
 
 	if cfg.FailedUpdateTTL > -1 {
 		f.Errors = NewShardedMap(Config{
@@ -353,9 +357,16 @@ func (f *Failover) doBuild(
 		return nil, err
 	}
 
-	writeErr := f.backend.Write(ctx, key, uVal)
-	if writeErr != nil {
-		return nil, writeErr
+	if f.wr != nil {
+		uVal, err = f.wr.WriteAndRead(ctx, key, uVal)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		writeErr := f.backend.Write(ctx, key, uVal)
+		if writeErr != nil {
+			return nil, writeErr
+		}
 	}
 
 	if f.config.ObserveMutability && value != nil {

--- a/failover_by_go1.18.go
+++ b/failover_by_go1.18.go
@@ -62,7 +62,9 @@ type FailoverBy[K comparable, V any] struct {
 	// Errors caches errors of failed updates.
 	Errors *ShardedMapBy[K, error]
 
-	backend  ReadWriterBy[K, V]
+	backend ReadWriterBy[K, V]
+	wr      WriteAndReaderBy[K, V]
+
 	lock     sync.Mutex
 	keyLocks map[K]*klBy[V]
 	config   FailoverConfigBy[K, V]
@@ -97,6 +99,8 @@ func NewFailoverBy[K comparable, V any](options ...func(cfg *FailoverConfigBy[K,
 		cfg.BackendConfig.Stats = cfg.Stats
 		f.backend = NewShardedMapBy[K, V](cfg.BackendConfig.Use)
 	}
+
+	f.wr, _ = f.backend.(WriteAndReaderBy[K, V])
 
 	if cfg.FailedUpdateTTL > -1 {
 		f.Errors = NewShardedMapBy[K, error](ConfigBy[K]{
@@ -316,9 +320,16 @@ func (f *FailoverBy[K, V]) doBuild(
 		return v, err
 	}
 
-	writeErr := f.backend.Write(ctx, key, uVal)
-	if writeErr != nil {
-		return v, writeErr
+	if f.wr != nil {
+		uVal, err = f.wr.WriteAndRead(ctx, key, uVal)
+		if err != nil {
+			return v, err
+		}
+	} else {
+		writeErr := f.backend.Write(ctx, key, uVal)
+		if writeErr != nil {
+			return v, writeErr
+		}
 	}
 
 	if f.config.ObserveMutability && hasPreviousValue {

--- a/failover_go1.18.go
+++ b/failover_go1.18.go
@@ -67,7 +67,9 @@ type FailoverOf[V any] struct {
 	// Errors caches errors of failed updates.
 	Errors *ShardedMapOf[error]
 
-	backend  ReadWriterOf[V]
+	backend ReadWriterOf[V]
+	wr      WriteAndReaderOf[V]
+
 	lock     sync.Mutex          // Securing keyLocks
 	keyLocks map[string]*klOf[V] // Preventing update concurrency per key
 	config   FailoverConfigOf[V]
@@ -105,6 +107,8 @@ func NewFailoverOf[V any](options ...func(cfg *FailoverConfigOf[V])) *FailoverOf
 		cfg.BackendConfig.Stats = cfg.Stats
 		f.backend = NewShardedMapOf[V](cfg.BackendConfig.Use)
 	}
+
+	f.wr, _ = f.backend.(WriteAndReaderOf[V])
 
 	if cfg.FailedUpdateTTL > -1 {
 		f.Errors = NewShardedMapOf[error](Config{
@@ -335,9 +339,16 @@ func (f *FailoverOf[V]) doBuild(
 		return v, err
 	}
 
-	writeErr := f.backend.Write(ctx, key, uVal)
-	if writeErr != nil {
-		return v, writeErr
+	if f.wr != nil {
+		uVal, err = f.wr.WriteAndRead(ctx, key, uVal)
+		if err != nil {
+			return v, err
+		}
+	} else {
+		writeErr := f.backend.Write(ctx, key, uVal)
+		if writeErr != nil {
+			return v, writeErr
+		}
 	}
 
 	if f.config.ObserveMutability && err == nil {

--- a/filecache/example_test.go
+++ b/filecache/example_test.go
@@ -1,0 +1,63 @@
+package filecache_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/bool64/cache"
+	"github.com/bool64/cache/blob"
+	"github.com/bool64/cache/filecache"
+)
+
+func ExampleFailover() {
+	ctx := context.Background()
+
+	dir, err := os.MkdirTemp("", "cache-filecache-example-*")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer os.RemoveAll(dir)
+
+	st, err := filecache.NewStorage(dir)
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		_ = st.Close()
+	}()
+
+	f := cache.NewFailoverOf[blob.Entry](func(cfg *cache.FailoverConfigOf[blob.Entry]) {
+		cfg.Backend = st
+	})
+
+	entry, err := f.Get(ctx, []byte("photo:1"), func(ctx context.Context) (blob.Entry, error) {
+		return blob.FromReader(bytes.NewBufferString("hello blob"), blob.Meta{
+			Name: "photo.txt",
+		}), nil
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	rc, err := entry.Open()
+	if err != nil {
+		panic(err)
+	}
+	defer rc.Close()
+
+	b, err := io.ReadAll(rc)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(entry.Meta().Name, string(b))
+
+	// Output:
+	// photo.txt hello blob
+}

--- a/filecache/failover_integration_go1.18_test.go
+++ b/filecache/failover_integration_go1.18_test.go
@@ -1,0 +1,49 @@
+//go:build go1.18
+// +build go1.18
+
+package filecache_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/bool64/cache"
+	"github.com/bool64/cache/blob"
+	"github.com/bool64/cache/filecache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFailoverOf_blobEntry_returnsStoredEntryForOneShotSource(t *testing.T) {
+	dir := t.TempDir()
+
+	st, err := filecache.NewStorage(dir)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, st.Close())
+	}()
+
+	f := cache.NewFailoverOf[blob.Entry](func(cfg *cache.FailoverConfigOf[blob.Entry]) {
+		cfg.Backend = st
+	})
+
+	ctx := context.Background()
+
+	entry, err := f.Get(ctx, []byte("photo:1"), func(ctx context.Context) (blob.Entry, error) {
+		return blob.FromReader(bytes.NewBufferString("hello"), blob.Meta{Name: "photo.txt"}), nil
+	})
+	require.NoError(t, err)
+
+	rc, err := entry.Open()
+	require.NoError(t, err)
+	defer rc.Close()
+
+	b, err := io.ReadAll(rc)
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello", string(b))
+	assert.Equal(t, "photo.txt", entry.Meta().Name)
+}

--- a/filecache/storage_go1.18.go
+++ b/filecache/storage_go1.18.go
@@ -1,0 +1,531 @@
+//go:build go1.18
+// +build go1.18
+
+// Package filecache provides a local filesystem-backed implementation of
+// cache.ReadWriterOf[blob.Entry] with persistent snapshots and immutable blob files.
+package filecache
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/gob"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/bool64/cache"
+	"github.com/bool64/cache/blob"
+)
+
+const (
+	indexFileName = "index.gob"
+	dataDirName   = "data"
+	fileExt       = ".blob"
+)
+
+// Storage is a local filesystem-backed blob storage.
+type Storage struct {
+	dir     string
+	dataDir string
+
+	index *cache.ShardedMapOf[blob.Entry]
+
+	mu      sync.Mutex
+	runtime map[string]*runtimeFile
+
+	closeOnce sync.Once
+}
+
+type storedEntry struct {
+	storage *Storage
+	meta    blob.Meta
+	version string
+}
+
+type persistedEntry struct {
+	Key      []byte
+	Meta     blob.Meta
+	Version  string
+	ExpireAt time.Time
+}
+
+type runtimeFile struct {
+	path string
+	refs int64
+	dead bool
+}
+
+// NewStorage creates a local filesystem-backed blob storage.
+func NewStorage(path string) (*Storage, error) {
+	s := &Storage{
+		dir:     path,
+		dataDir: filepath.Join(path, dataDirName),
+		runtime: make(map[string]*runtimeFile),
+	}
+
+	if err := os.MkdirAll(s.dataDir, 0o750); err != nil {
+		return nil, err
+	}
+
+	s.index = cache.NewShardedMapOf[blob.Entry](cache.Config{
+		Name:               "filecache:" + filepath.Base(path),
+		ExpirationJitter:   -1,
+		EvictionStrategy:   cache.EvictMostExpired,
+		TimeToLive:         cache.UnlimitedTTL,
+		DeleteExpiredAfter: 24 * time.Hour,
+		OnDelete: func(_ []byte, value interface{}) {
+			if entry, ok := value.(blob.Entry); ok {
+				s.markDead(entry)
+			}
+		},
+	}.Use)
+
+	if err := s.restoreIndex(); err != nil {
+		s.index = nil
+
+		return nil, err
+	}
+
+	if err := s.reconcileFiles(); err != nil {
+		s.index = nil
+
+		return nil, err
+	}
+
+	return s, nil
+}
+
+// Read reads a blob entry by key.
+func (s *Storage) Read(ctx context.Context, key []byte) (blob.Entry, error) {
+	return s.index.Read(ctx, key)
+}
+
+// Write materializes a blob entry into local storage and updates the index.
+func (s *Storage) Write(ctx context.Context, key []byte, entry blob.Entry) error {
+	_, err := s.WriteAndRead(ctx, key, entry)
+
+	return err
+}
+
+// WriteAndRead materializes a blob entry into local storage, updates the index, and returns the stored entry.
+func (s *Storage) WriteAndRead(ctx context.Context, key []byte, entry blob.Entry) (blob.Entry, error) {
+	rc, err := entry.Open()
+	if err != nil {
+		return nil, err
+	}
+
+	version, err := newVersion()
+	if err != nil {
+		_ = rc.Close()
+
+		return nil, err
+	}
+
+	finalPath := s.pathForVersion(version)
+	if err := os.MkdirAll(filepath.Dir(finalPath), 0o750); err != nil {
+		_ = rc.Close()
+
+		return nil, err
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(finalPath), version+".tmp-*")
+	if err != nil {
+		_ = rc.Close()
+
+		return nil, err
+	}
+
+	tmpName := tmp.Name()
+	cleanupTemp := func() {
+		_ = os.Remove(tmpName)
+	}
+
+	if _, err := io.Copy(tmp, rc); err != nil {
+		_ = tmp.Close()
+		_ = rc.Close()
+
+		cleanupTemp()
+
+		return nil, err
+	}
+
+	if err := tmp.Close(); err != nil {
+		_ = rc.Close()
+
+		cleanupTemp()
+
+		return nil, err
+	}
+
+	if err := rc.Close(); err != nil {
+		cleanupTemp()
+
+		return nil, err
+	}
+
+	if err := os.Rename(tmpName, finalPath); err != nil {
+		cleanupTemp()
+
+		return nil, err
+	}
+
+	newEntry := &storedEntry{
+		storage: s,
+		meta:    entry.Meta(),
+		version: version,
+	}
+
+	s.ensureRuntime(version, finalPath)
+
+	oldEntry, _ := s.currentEntry(ctx, key)
+
+	if err := s.index.Write(ctx, key, newEntry); err != nil {
+		s.markDead(newEntry)
+
+		return nil, err
+	}
+
+	if oldEntry != nil {
+		s.markDead(oldEntry)
+	}
+
+	return newEntry, nil
+}
+
+// Delete deletes a blob entry by key.
+func (s *Storage) Delete(ctx context.Context, key []byte) error {
+	return s.index.Delete(ctx, key)
+}
+
+// Close dumps the in-memory index and stops background jobs.
+func (s *Storage) Close() error {
+	var err error
+
+	s.closeOnce.Do(func() {
+		err = s.dumpIndex()
+		if reconcileErr := s.reconcileFiles(); err == nil {
+			err = reconcileErr
+		}
+
+		s.index = nil
+	})
+
+	return err
+}
+
+func (e *storedEntry) Meta() blob.Meta {
+	return e.meta
+}
+
+func (e *storedEntry) Open() (io.ReadCloser, error) {
+	return e.storage.openVersion(e.version)
+}
+
+func (s *Storage) currentEntry(ctx context.Context, key []byte) (blob.Entry, bool) {
+	entry, err := s.index.Read(ctx, key)
+	if err == nil {
+		return entry, true
+	}
+
+	var errExpired cache.ErrWithExpiredItemOf[blob.Entry]
+	if errors.As(err, &errExpired) {
+		return errExpired.Value(), true
+	}
+
+	return nil, false
+}
+
+func (s *Storage) openVersion(version string) (io.ReadCloser, error) {
+	path := s.pathForVersion(version)
+	rt := s.ensureRuntime(version, path)
+	atomic.AddInt64(&rt.refs, 1)
+
+	//nolint:gosec // Path is derived from internal versioned storage layout, not external input.
+	f, err := os.Open(path)
+	if err != nil {
+		atomic.AddInt64(&rt.refs, -1)
+
+		return nil, err
+	}
+
+	return &trackedFile{
+		File: f,
+		release: func() {
+			s.releaseVersion(version)
+		},
+	}, nil
+}
+
+func (s *Storage) releaseVersion(version string) {
+	s.mu.Lock()
+	rt := s.runtime[version]
+	s.mu.Unlock()
+
+	if rt == nil {
+		return
+	}
+
+	if atomic.AddInt64(&rt.refs, -1) == 0 {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		rt = s.runtime[version]
+		if rt == nil || atomic.LoadInt64(&rt.refs) != 0 || !rt.dead {
+			return
+		}
+
+		_ = os.Remove(rt.path)
+
+		delete(s.runtime, version)
+	}
+}
+
+func (s *Storage) ensureRuntime(version, path string) *runtimeFile {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if rt, ok := s.runtime[version]; ok {
+		if rt.path == "" {
+			rt.path = path
+		}
+
+		return rt
+	}
+
+	rt := &runtimeFile{path: path}
+	s.runtime[version] = rt
+
+	return rt
+}
+
+func (s *Storage) markDead(entry blob.Entry) {
+	se, ok := entry.(*storedEntry)
+	if !ok || se == nil {
+		return
+	}
+
+	path := s.pathForVersion(se.version)
+
+	s.mu.Lock()
+	rt := s.runtime[se.version]
+
+	if rt == nil {
+		rt = &runtimeFile{path: path}
+		s.runtime[se.version] = rt
+	}
+
+	rt.dead = true
+	refs := atomic.LoadInt64(&rt.refs)
+	s.mu.Unlock()
+
+	if refs == 0 {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		rt = s.runtime[se.version]
+		if rt == nil || atomic.LoadInt64(&rt.refs) != 0 || !rt.dead {
+			return
+		}
+
+		_ = os.Remove(rt.path)
+
+		delete(s.runtime, se.version)
+	}
+}
+
+func (s *Storage) restoreIndex() error {
+	f, err := os.Open(filepath.Join(s.dir, indexFileName))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+
+		return err
+	}
+	defer f.Close()
+
+	var entries []persistedEntry
+	if err := gob.NewDecoder(f).Decode(&entries); err != nil {
+		return err
+	}
+
+	now := time.Now()
+
+	for _, pe := range entries {
+		if _, err := os.Stat(s.pathForVersion(pe.Version)); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+
+			return err
+		}
+
+		ctx := context.Background()
+		if pe.ExpireAt.UnixNano() != 0 {
+			ctx = cache.WithTTL(ctx, pe.ExpireAt.Sub(now), false)
+		}
+
+		entry := &storedEntry{
+			storage: s,
+			meta:    pe.Meta,
+			version: pe.Version,
+		}
+
+		s.ensureRuntime(pe.Version, s.pathForVersion(pe.Version))
+
+		if err := s.index.Write(ctx, pe.Key, entry); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *Storage) dumpIndex() error {
+	entries := make([]persistedEntry, 0)
+
+	_, err := s.index.Walk(func(entry cache.EntryOf[blob.Entry]) error {
+		se, ok := entry.Value().(*storedEntry)
+		if !ok || se == nil {
+			return fmt.Errorf("unexpected entry type %T", entry.Value())
+		}
+
+		key := append([]byte(nil), entry.Key()...)
+		entries = append(entries, persistedEntry{
+			Key:      key,
+			Meta:     se.meta,
+			Version:  se.version,
+			ExpireAt: entry.ExpireAt(),
+		})
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp(s.dir, indexFileName+".tmp-*")
+	if err != nil {
+		return err
+	}
+
+	tmpName := tmp.Name()
+	defer func() {
+		_ = os.Remove(tmpName)
+	}()
+
+	if err := gob.NewEncoder(tmp).Encode(entries); err != nil {
+		_ = tmp.Close()
+
+		return err
+	}
+
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpName, filepath.Join(s.dir, indexFileName))
+}
+
+func (s *Storage) reconcileFiles() error {
+	referenced := make(map[string]struct{})
+	busyPaths := make(map[string]struct{})
+
+	_, err := s.index.Walk(func(entry cache.EntryOf[blob.Entry]) error {
+		se, ok := entry.Value().(*storedEntry)
+		if !ok || se == nil {
+			return fmt.Errorf("unexpected entry type %T", entry.Value())
+		}
+
+		referenced[s.pathForVersion(se.version)] = struct{}{}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	for _, rt := range s.runtime {
+		if atomic.LoadInt64(&rt.refs) > 0 {
+			busyPaths[rt.path] = struct{}{}
+		}
+	}
+	s.mu.Unlock()
+
+	return filepath.Walk(s.dataDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if filepath.Ext(path) != fileExt && filepath.Ext(path) != ".tmp" {
+			return nil
+		}
+
+		if filepath.Ext(path) == ".tmp" {
+			//nolint:gosec // Reconciliation only removes files under application-owned cache storage.
+			return os.Remove(path)
+		}
+
+		if _, busy := busyPaths[path]; busy {
+			return nil
+		}
+
+		if _, ok := referenced[path]; ok {
+			return nil
+		}
+
+		//nolint:gosec // Reconciliation only removes files under application-owned cache storage.
+		return os.Remove(path)
+	})
+}
+
+func (s *Storage) pathForVersion(version string) string {
+	path := s.dataDir
+	if len(version) >= 2 {
+		path = filepath.Join(path, version[:2])
+	}
+
+	if len(version) >= 4 {
+		path = filepath.Join(path, version[2:4])
+	}
+
+	return filepath.Join(path, version+fileExt)
+}
+
+func newVersion() (string, error) {
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%d%s", time.Now().UTC().UnixNano(), hex.EncodeToString(buf[:])), nil
+}
+
+type trackedFile struct {
+	*os.File
+
+	once    sync.Once
+	release func()
+}
+
+func (t *trackedFile) Close() error {
+	err := t.File.Close()
+	t.once.Do(func() {
+		if t.release != nil {
+			t.release()
+		}
+	})
+
+	return err
+}

--- a/filecache/storage_go1.18_test.go
+++ b/filecache/storage_go1.18_test.go
@@ -1,0 +1,124 @@
+//go:build go1.18
+// +build go1.18
+
+package filecache
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/bool64/cache/blob"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorage_persistedIndex(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := NewStorage(dir)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, s.Write(ctx, []byte("k1"), blob.FromReader(bytes.NewBufferString("value"), blob.Meta{
+		Name: "a.txt",
+	})))
+	require.NoError(t, s.Close())
+
+	s, err = NewStorage(dir)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, s.Close())
+	}()
+
+	entry, err := s.Read(ctx, []byte("k1"))
+	require.NoError(t, err)
+	assert.Equal(t, "a.txt", entry.Meta().Name)
+
+	rc, err := entry.Open()
+	require.NoError(t, err)
+	defer rc.Close()
+
+	b, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "value", string(b))
+}
+
+func TestStorage_rewriteDeletesOldVersionAfterLastClose(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := NewStorage(dir)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, s.Close())
+	}()
+
+	ctx := context.Background()
+	key := []byte("same")
+
+	require.NoError(t, s.Write(ctx, key, blob.FromReader(bytes.NewBufferString("v1"), blob.Meta{Name: "v1.txt"})))
+
+	entry, err := s.Read(ctx, key)
+	require.NoError(t, err)
+
+	oldStored, ok := entry.(*storedEntry)
+	require.True(t, ok)
+
+	oldPath := s.pathForVersion(oldStored.version)
+
+	rc, err := entry.Open()
+	require.NoError(t, err)
+
+	require.NoError(t, s.Write(ctx, key, blob.FromReader(bytes.NewBufferString("v2"), blob.Meta{Name: "v2.txt"})))
+
+	_, err = os.Stat(oldPath)
+	require.NoError(t, err)
+
+	require.NoError(t, rc.Close())
+
+	_, err = os.Stat(oldPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	newEntry, err := s.Read(ctx, key)
+	require.NoError(t, err)
+
+	newRC, err := newEntry.Open()
+	require.NoError(t, err)
+	defer newRC.Close()
+
+	b, err := io.ReadAll(newRC)
+	require.NoError(t, err)
+	assert.Equal(t, "v2", string(b))
+}
+
+func TestStorage_deleteRemovesFile(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := NewStorage(dir)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, s.Close())
+	}()
+
+	ctx := context.Background()
+	key := []byte("delete-me")
+
+	require.NoError(t, s.Write(ctx, key, blob.FromReader(bytes.NewBufferString("gone"), blob.Meta{})))
+	entry, err := s.Read(ctx, key)
+	require.NoError(t, err)
+
+	se, ok := entry.(*storedEntry)
+	require.True(t, ok)
+
+	path := s.pathForVersion(se.version)
+
+	require.NoError(t, s.Delete(ctx, key))
+
+	_, err = os.Stat(path)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/sharded_map.go
+++ b/sharded_map.go
@@ -148,14 +148,18 @@ func (c *shardedMap) Delete(ctx context.Context, key []byte) error {
 	b := &c.hashedBuckets[h%shards]
 
 	b.Lock()
-	defer b.Unlock()
-
 	cachedEntry, found := b.data[h]
+
 	if !found || !bytes.Equal(cachedEntry.K, key) {
+		b.Unlock()
+
 		return ErrNotFound
 	}
 
 	delete(b.data, h)
+	b.Unlock()
+
+	c.notifyDeletedEntry(*cachedEntry)
 
 	c.t.NotifyDeleted(ctx, key)
 
@@ -186,12 +190,23 @@ func (c *shardedMap) ExpireAll(ctx context.Context) {
 func (c *shardedMap) DeleteAll(ctx context.Context) {
 	now := time.Now()
 	cnt := 0
+	collectRemoved := c.t.Config.OnDelete != nil
+
+	var removed []TraitEntry
+
+	if collectRemoved {
+		removed = make([]TraitEntry, 0)
+	}
 
 	for i := range c.hashedBuckets {
 		b := &c.hashedBuckets[i]
 
 		b.Lock()
-		for h := range c.hashedBuckets[i].data {
+		for h, v := range c.hashedBuckets[i].data {
+			if collectRemoved {
+				removed = append(removed, *v)
+			}
+
 			delete(b.data, h)
 
 			cnt++
@@ -199,11 +214,19 @@ func (c *shardedMap) DeleteAll(ctx context.Context) {
 		b.Unlock()
 	}
 
+	c.notifyDeletedEntries(removed)
 	c.t.NotifyDeletedAll(ctx, now, cnt)
 }
 
 func (c *shardedMap) deleteExpired(before time.Time) {
 	beforeTS := ts(before)
+	collectRemoved := c.t.Config.OnDelete != nil
+
+	var removed []TraitEntry
+
+	if collectRemoved {
+		removed = make([]TraitEntry, 0)
+	}
 
 	for i := range c.hashedBuckets {
 		b := &c.hashedBuckets[i]
@@ -211,11 +234,17 @@ func (c *shardedMap) deleteExpired(before time.Time) {
 		b.Lock()
 		for h, v := range b.data {
 			if v.E < beforeTS {
+				if collectRemoved {
+					removed = append(removed, *v)
+				}
+
 				delete(b.data, h)
 			}
 		}
 		b.Unlock()
 	}
+
+	c.notifyDeletedEntries(removed)
 }
 
 // Len returns number of elements in cache.
@@ -359,9 +388,29 @@ func (c *shardedMap) evictLeast(evictFraction float64, val func(i *TraitEntry) i
 		b := &c.hashedBuckets[h%shards]
 
 		b.Lock()
+		if removed, found := b.data[h]; found {
+			c.notifyDeletedEntry(*removed)
+		}
+
 		delete(b.data, h)
 		b.Unlock()
 	}
 
 	return evictItems
+}
+
+func (c *shardedMap) notifyDeletedEntries(entries []TraitEntry) {
+	if c.t.Config.OnDelete == nil {
+		return
+	}
+
+	for _, entry := range entries {
+		c.t.Config.OnDelete(entry.K, entry.V)
+	}
+}
+
+func (c *shardedMap) notifyDeletedEntry(entry TraitEntry) {
+	if c.t.Config.OnDelete != nil {
+		c.t.Config.OnDelete(entry.K, entry.V)
+	}
 }

--- a/sharded_map_go1.18.go
+++ b/sharded_map_go1.18.go
@@ -155,15 +155,18 @@ func (c *shardedMapOf[V]) Delete(ctx context.Context, key []byte) error {
 	b := &c.hashedBuckets[h%shards]
 
 	b.Lock()
-	defer b.Unlock()
-
 	cachedEntry, found := b.data[h]
+
 	if !found || !bytes.Equal(cachedEntry.K, key) {
+		b.Unlock()
+
 		return ErrNotFound
 	}
 
 	delete(b.data, h)
+	b.Unlock()
 
+	c.notifyDeletedEntry(*cachedEntry)
 	c.t.NotifyDeleted(ctx, key)
 
 	return nil
@@ -193,12 +196,23 @@ func (c *shardedMapOf[V]) ExpireAll(ctx context.Context) {
 func (c *shardedMapOf[V]) DeleteAll(ctx context.Context) {
 	start := time.Now()
 	cnt := 0
+	collectRemoved := c.t.Config.OnDelete != nil
+
+	var removed []TraitEntryOf[V]
+
+	if collectRemoved {
+		removed = make([]TraitEntryOf[V], 0)
+	}
 
 	for i := range c.hashedBuckets {
 		b := &c.hashedBuckets[i]
 
 		b.Lock()
-		for h := range c.hashedBuckets[i].data {
+		for h, v := range c.hashedBuckets[i].data {
+			if collectRemoved {
+				removed = append(removed, *v)
+			}
+
 			delete(b.data, h)
 
 			cnt++
@@ -206,11 +220,19 @@ func (c *shardedMapOf[V]) DeleteAll(ctx context.Context) {
 		b.Unlock()
 	}
 
+	c.notifyDeletedEntries(removed)
 	c.t.NotifyDeletedAll(ctx, start, cnt)
 }
 
 func (c *shardedMapOf[V]) deleteExpired(before time.Time) {
 	beforeTS := ts(before)
+	collectRemoved := c.t.Config.OnDelete != nil
+
+	var removed []TraitEntryOf[V]
+
+	if collectRemoved {
+		removed = make([]TraitEntryOf[V], 0)
+	}
 
 	for i := range c.hashedBuckets {
 		b := &c.hashedBuckets[i]
@@ -218,11 +240,17 @@ func (c *shardedMapOf[V]) deleteExpired(before time.Time) {
 		b.Lock()
 		for h, v := range b.data {
 			if v.E < beforeTS {
+				if collectRemoved {
+					removed = append(removed, *v)
+				}
+
 				delete(b.data, h)
 			}
 		}
 		b.Unlock()
 	}
+
+	c.notifyDeletedEntries(removed)
 }
 
 // Len returns number of elements in cache.
@@ -412,9 +440,29 @@ func (c *shardedMapOf[V]) evictLeast(evictFraction float64, val func(i *TraitEnt
 		b := &c.hashedBuckets[h%shards]
 
 		b.Lock()
+		if removed, found := b.data[h]; found {
+			c.notifyDeletedEntry(*removed)
+		}
+
 		delete(b.data, h)
 		b.Unlock()
 	}
 
 	return evictItems
+}
+
+func (c *shardedMapOf[V]) notifyDeletedEntries(entries []TraitEntryOf[V]) {
+	if c.t.Config.OnDelete == nil {
+		return
+	}
+
+	for _, entry := range entries {
+		c.t.Config.OnDelete(entry.K, entry.V)
+	}
+}
+
+func (c *shardedMapOf[V]) notifyDeletedEntry(entry TraitEntryOf[V]) {
+	if c.t.Config.OnDelete != nil {
+		c.t.Config.OnDelete(entry.K, entry.V)
+	}
 }

--- a/sync_map.go
+++ b/sync_map.go
@@ -93,7 +93,10 @@ func (c *syncMap) Write(ctx context.Context, k []byte, v interface{}) error {
 
 // Delete removes values by the key.
 func (c *syncMap) Delete(ctx context.Context, key []byte) error {
-	c.data.Delete(string(key))
+	if value, found := c.data.LoadAndDelete(string(key)); found && c.t.Config.OnDelete != nil {
+		entry := value.(*TraitEntry)
+		c.t.Config.OnDelete(entry.K, entry.V)
+	}
 
 	c.t.NotifyDeleted(ctx, key)
 
@@ -122,14 +125,31 @@ func (c *syncMap) ExpireAll(ctx context.Context) {
 func (c *syncMap) DeleteAll(ctx context.Context) {
 	start := time.Now()
 	cnt := 0
+	collectRemoved := c.t.Config.OnDelete != nil
 
-	c.data.Range(func(key, _ interface{}) bool {
+	var removed []TraitEntry
+
+	if collectRemoved {
+		removed = make([]TraitEntry, 0)
+	}
+
+	c.data.Range(func(key, value interface{}) bool {
+		if collectRemoved {
+			removed = append(removed, *value.(*TraitEntry))
+		}
+
 		c.data.Delete(key)
 
 		cnt++
 
 		return true
 	})
+
+	for _, entry := range removed {
+		if c.t.Config.OnDelete != nil {
+			c.t.Config.OnDelete(entry.K, entry.V)
+		}
+	}
 
 	c.t.NotifyDeletedAll(ctx, start, cnt)
 }
@@ -141,6 +161,10 @@ func (c *syncMap) deleteExpired(before time.Time) {
 		cacheEntry := value.(*TraitEntry)
 		if cacheEntry.E < beforeTS {
 			c.data.Delete(key)
+
+			if c.t.Config.OnDelete != nil {
+				c.t.Config.OnDelete(cacheEntry.K, cacheEntry.V)
+			}
 		}
 
 		return true


### PR DESCRIPTION
## Summary

This change introduces a blob-oriented cache abstraction and a local filesystem-backed blob storage MVP, while reusing the existing cache backends and failover flow.

The main additions are:

- new `blob` package with generic blob descriptors and helper constructors
- new `filecache` package with persistent local storage for `blob.Entry`
- new `blob/DESIGN.md` documenting the blob cache design and rationale
- generic `WriteAndRead` backend capability so `Failover*` can return backend-normalized values after write
- public `Config.OnDelete(key, value)` lifecycle hook on cache backends
- tests, examples, and lint/doc cleanup for the new functionality

## Motivation

The target use case is caching files or blobs, especially for HTTP-serving scenarios, without forcing the whole payload into memory.

The design keeps:

- `cache.Failover*` and `ReadWriter*` as the main coordination/storage contracts
- blob-specific concepts outside the root `cache` package
- backend normalization in the backend itself instead of in failover-specific wrappers

## What Changed

### New `blob` package

Added a generic blob abstraction:

- `blob.Meta`
- `blob.Entry`
- `blob.FromReader`
- `blob.FromReadCloser`
- `blob.FromHTTPResponse`

`blob.Entry` is a stable cached descriptor with:

```go
Meta() Meta
Open() (io.ReadCloser, error)
```

This keeps the cached value stable while allowing callers to open fresh readers per use.

### New `filecache` package

Added `filecache.Storage`, a local filesystem-backed implementation of:

```go
cache.ReadWriterOf[blob.Entry]
```

Current behavior:

- stores immutable versioned files on disk
- keeps an internal in-memory index via `cache.ShardedMapOf[blob.Entry]`
- restores index snapshot on startup
- dumps snapshot on `Storage.Close()`
- tracks open readers with per-version refcounts
- deletes dead versions on last close
- reconciles orphaned/temp files on startup and close

### Generic `WriteAndRead` capability

Added optional backend capabilities:

- `cache.WriteAndReader`
- `cache.WriteAndReaderOf[V]`
- `cache.WriteAndReaderBy[K, V]`

`Failover`, `FailoverOf`, and `FailoverBy` now detect this capability once during construction and use it after successful writes.

This fixes an important correctness issue for transient one-shot values such as `blob.FromReader(...)` or `blob.FromHTTPResponse(...)`:

- before: `FailoverOf[blob.Entry]` returned the builder’s transient entry after `Write`
- now: if backend supports `WriteAndRead`, failover returns the backend-normalized stored value

`filecache.Storage` implements `WriteAndRead`, so plain `cache.NewFailoverOf[blob.Entry]` now works correctly with transient blob sources.

### `Config.OnDelete`

Added public cache lifecycle hook:

```go
Config.OnDelete func(key []byte, value interface{})
```

Wired through:

- `ShardedMap`
- `ShardedMapOf`
- `SyncMap`

The hook fires when entries are removed by:

- explicit `Delete`
- `DeleteAll`
- expiration cleanup
- eviction

This is used by `filecache` for cleanup and is also available for userland side effects such as invalidation index maintenance.

## Examples and Tests

Added:

- package comments for `blob` and `filecache`
- `blob` tests for helper constructors
- `filecache` tests for:
  - persisted index restore
  - immutable rewrite and delete-on-last-close
  - delete cleanup
  - failover integration with transient one-shot blob entries
- `filecache` example showing `cache.NewFailoverOf[blob.Entry]` with `filecache.Storage`

## Implementation Notes

- `filecache.Storage.Close()` is explicit and required because it flushes the snapshot.
- Internal sharded-map goroutine cleanup still relies on the existing finalizer behavior; there is no public `ShardedMapOf.Close()`.
- `blob.HTTPExtra` is gob-registered in package init with a targeted lint suppression because `filecache` dump/restore needs it.
- `Meta.Extra` gob compatibility is treated as a `filecache` implementation detail, not a `blob` contract.
