### PR TITLE
Redefine filecache, redesign configs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters:
     - tagliatelle
     - testableexamples
     - testifylint
+    - modernize
     - varnamelen
     - wrapcheck
   settings:

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ with [`reflect.DeepEqual`](https://pkg.go.dev/reflect#DeepEqual) and may affect 
 
 ## Blob Cache
 
-For streamed file/blob workloads, the library also provides a blob-oriented abstraction and a local filesystem-backed
-storage implementation.
+For streamed file/blob workloads, the library also provides a blob-oriented abstraction and storage backends that let
+you keep the same application-facing API while changing storage economics as the dataset grows.
 
 [`blob.Entry`](https://pkg.go.dev/github.com/bool64/cache/blob#Entry) is a reopenable descriptor of content:
 
@@ -121,9 +121,15 @@ type Entry interface {
 
 This keeps the cached value stable while letting callers open a fresh reader on demand.
 
+The idea is to use one blob language across hot and cold tiers:
+
+* in-memory backends can return lightweight reopenable readers over bytes
+* `filecache` can spill colder data to local disk
+* future DB-backed blob storage can persist even larger datasets without changing caller code
+
 [`filecache.Storage`](https://pkg.go.dev/github.com/bool64/cache/filecache#Storage) implements
-[`cache.ReadWriterOf[blob.Entry]`](https://pkg.go.dev/github.com/bool64/cache#ReadWriterOf) and persists immutable blob
-files on local disk together with a compact in-memory index snapshot.
+[`cache.ReadWriterBy[K, blob.Entry]`](https://pkg.go.dev/github.com/bool64/cache#ReadWriterBy) and persists immutable
+blob files on local disk together with a compact in-memory index snapshot.
 
 Blob sources can be created with helpers from the [`blob`](https://pkg.go.dev/github.com/bool64/cache/blob) package,
 for example:
@@ -132,10 +138,24 @@ for example:
 * [`blob.FromReadCloser`](https://pkg.go.dev/github.com/bool64/cache/blob#FromReadCloser)
 * [`blob.FromHTTPResponse`](https://pkg.go.dev/github.com/bool64/cache/blob#FromHTTPResponse)
 
+Blob-specific retention settings live in
+[`blob.RetentionPolicy`](https://pkg.go.dev/github.com/bool64/cache/blob#RetentionPolicy), while cache/index behavior
+such as TTL and eviction strategy stays in [`cache.Policy`](https://pkg.go.dev/github.com/bool64/cache#Policy).
+
 Failover works with blob entries as well:
 
 ```go
-storage, _ := filecache.NewStorage("/var/cache/photos")
+storage, _ := filecache.NewStorage[string](
+    "/var/cache/photos",
+    filecache.Config[string]{
+        IndexPolicy: cache.Policy{
+            TimeToLive: cache.UnlimitedTTL,
+        },
+        RetentionPolicy: blob.RetentionPolicy{
+            StoredBytesSoftLimit: 1 << 30, // 1 GiB soft limit for stored payloads.
+        },
+    }.Use,
+)
 
 f := cache.NewFailoverOf[blob.Entry](func(cfg *cache.FailoverConfigOf[blob.Entry]) {
     cfg.Backend = storage
@@ -165,6 +185,11 @@ defer rc.Close()
 The local file-backed implementation currently requires explicit
 [`Storage.Close()`](https://pkg.go.dev/github.com/bool64/cache/filecache#Storage.Close) to flush the index snapshot on
 application shutdown.
+
+`filecache.Config[K]` also supports:
+
+* `IndexShardFunc` to customize typed-key shard routing for the in-memory index
+* `SplitPath` to control how blob version paths are partitioned into nested directories
 
 ## Sharded Map
 
@@ -239,7 +264,7 @@ bits are not well distributed. Mixing folds higher bits into lower ones before s
 distribution under concurrent access.
 
 For unsupported `K comparable` types, `NewShardedMapBy` panics at construction unless a custom sharder is configured in
-`ConfigBy[K]`. This keeps misconfiguration deterministic and avoids pushing sharder errors into hot-path APIs.
+`ConfigBy[K, V]`. This keeps misconfiguration deterministic and avoids pushing sharder errors into hot-path APIs.
 
 `ShardFunc` is also the escape hatch for performance-sensitive workloads. The built-in sharders are intended to be
 good general-purpose defaults, while a custom typed sharder can be slightly faster for hot paths with well-understood

--- a/bench/by_go1.18.go
+++ b/bench/by_go1.18.go
@@ -195,7 +195,7 @@ func init() {
 
 	ReadWriters = append(ReadWriters,
 		ReadWriterByRunner{F: func() cache.ReadWriterBy[string, SmallCachedValue] {
-			return cache.NewShardedMapBy[string, SmallCachedValue](func(cfg *cache.ConfigBy[string]) {
+			return cache.NewShardedMapBy[string, SmallCachedValue](func(cfg *cache.ConfigBy[string, SmallCachedValue]) {
 				cfg.CountSoftLimit = 1e10
 				cfg.EvictionStrategy = cache.EvictLeastRecentlyUsed
 			})

--- a/blob/blob.go
+++ b/blob/blob.go
@@ -11,6 +11,13 @@ import (
 	"time"
 )
 
+// RetentionPolicy contains blob-storage retention and eviction settings.
+type RetentionPolicy struct {
+	// StoredBytesSoftLimit triggers eviction when total stored blob size exceeds this limit.
+	// Zero disables the check.
+	StoredBytesSoftLimit uint64
+}
+
 // Meta describes a blob.
 type Meta struct {
 	Name    string

--- a/by_go1.18_test.go
+++ b/by_go1.18_test.go
@@ -4,6 +4,7 @@
 package cache_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"runtime"
@@ -353,6 +354,46 @@ func TestNewShardedMapBy_customSharder(t *testing.T) {
 	require.NoError(t, c.Write(ctx, key{ID: 7}, "bar"))
 
 	v, err := c.Read(ctx, key{ID: 7})
+	require.NoError(t, err)
+	assert.Equal(t, "bar", v)
+}
+
+func TestShardedMapBy_DumpRestore_customSharder(t *testing.T) {
+	type key struct {
+		ID int
+	}
+
+	newCache := func() *cache.ShardedMapBy[key, string] {
+		return cache.NewShardedMapBy[key, string](func(cfg *cache.ConfigBy[key]) {
+			cfg.TimeToLive = time.Hour
+			cfg.ShardFunc = func(k key) uint64 {
+				return uint64(k.ID)
+			}
+		})
+	}
+
+	c1 := newCache()
+	c2 := newCache()
+	ctx := context.Background()
+
+	require.NoError(t, c1.Write(ctx, key{ID: 7}, "foo"))
+	require.NoError(t, c1.Write(ctx, key{ID: 11}, "bar"))
+
+	buf := bytes.NewBuffer(nil)
+
+	n, err := c1.Dump(buf)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	n, err = c2.Restore(buf)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	v, err := c2.Read(ctx, key{ID: 7})
+	require.NoError(t, err)
+	assert.Equal(t, "foo", v)
+
+	v, err = c2.Read(ctx, key{ID: 11})
 	require.NoError(t, err)
 	assert.Equal(t, "bar", v)
 }

--- a/by_go1.18_test.go
+++ b/by_go1.18_test.go
@@ -22,13 +22,13 @@ import (
 	"github.com/swaggest/assertjson"
 )
 
-func backendsBy[V any](options ...func(*cache.Config)) []interface {
+func backendsBy[V any](options ...func(*cache.Policy)) []interface {
 	cache.ReadWriterBy[string, V]
 	Len() int
 } {
-	sharded := cache.NewShardedMapBy[string, V](func(cfg *cache.ConfigBy[string]) {
+	sharded := cache.NewShardedMapBy[string, V](func(cfg *cache.ConfigBy[string, V]) {
 		for _, option := range options {
-			option(&cfg.Config)
+			option(&cfg.Policy)
 		}
 	})
 
@@ -37,7 +37,11 @@ func backendsBy[V any](options ...func(*cache.Config)) []interface {
 		Len() int
 	}{
 		sharded,
-		cache.NewSyncMapBy[string, V](options...),
+		cache.NewSyncMapBy[string, V](func(cfg *cache.ConfigBy[string, V]) {
+			for _, option := range options {
+				option(&cfg.Policy)
+			}
+		}),
 	}
 }
 
@@ -50,7 +54,7 @@ func TestNewShardedMapBy(t *testing.T) {
 	st := stats.TrackerMock{}
 
 	func() {
-		c := cache.NewShardedMapBy[string, string](func(config *cache.ConfigBy[string]) {
+		c := cache.NewShardedMapBy[string, string](func(config *cache.ConfigBy[string, string]) {
 			config.Logger = &logger
 			config.Stats = &st
 			config.Name = "test"
@@ -138,7 +142,7 @@ func TestNewShardedMapBy_noExpiration(t *testing.T) {
 	st := stats.TrackerMock{}
 
 	func() {
-		c := cache.NewShardedMapBy[string, string](func(config *cache.ConfigBy[string]) {
+		c := cache.NewShardedMapBy[string, string](func(config *cache.ConfigBy[string, string]) {
 			config.Logger = &logger
 			config.Stats = &st
 			config.Name = "test"
@@ -222,7 +226,7 @@ cache_write{name="test"} 1`, st.Metrics())
 }
 
 func TestNewShardedMapBy_Load_Store(t *testing.T) {
-	c := cache.NewShardedMapBy[string, string](func(config *cache.ConfigBy[string]) {
+	c := cache.NewShardedMapBy[string, string](func(config *cache.ConfigBy[string, string]) {
 		config.Name = "test"
 		config.TimeToLive = time.Hour
 	})
@@ -239,7 +243,7 @@ func TestNewSyncMapBy(t *testing.T) {
 	st := stats.TrackerMock{}
 
 	func() {
-		c := cache.NewSyncMapBy[string, string](func(config *cache.Config) {
+		c := cache.NewSyncMapBy[string, string](func(config *cache.ConfigBy[string, string]) {
 			config.Logger = &logger
 			config.Stats = &st
 			config.Name = "test"
@@ -343,7 +347,7 @@ func TestNewShardedMapBy_customSharder(t *testing.T) {
 		ID int
 	}
 
-	c := cache.NewShardedMapBy[key, string](func(cfg *cache.ConfigBy[key]) {
+	c := cache.NewShardedMapBy[key, string](func(cfg *cache.ConfigBy[key, string]) {
 		cfg.TimeToLive = time.Hour
 		cfg.ShardFunc = func(k key) uint64 {
 			return uint64(k.ID)
@@ -358,13 +362,32 @@ func TestNewShardedMapBy_customSharder(t *testing.T) {
 	assert.Equal(t, "bar", v)
 }
 
+func TestShardedMapBy_OnDelete(t *testing.T) {
+	var deleted []string
+
+	c := cache.NewShardedMapBy[string, string](func(cfg *cache.ConfigBy[string, string]) {
+		cfg.OnDeleteBy = func(key string, value string) {
+			deleted = append(deleted, key+":"+value)
+		}
+	})
+
+	ctx := context.Background()
+	require.NoError(t, c.Write(ctx, "k1", "v1"))
+	require.NoError(t, c.Write(ctx, "k2", "v2"))
+
+	require.NoError(t, c.Delete(ctx, "k1"))
+	c.DeleteAll(ctx)
+
+	assert.ElementsMatch(t, []string{"k1:v1", "k2:v2"}, deleted)
+}
+
 func TestShardedMapBy_DumpRestore_customSharder(t *testing.T) {
 	type key struct {
 		ID int
 	}
 
 	newCache := func() *cache.ShardedMapBy[key, string] {
-		return cache.NewShardedMapBy[key, string](func(cfg *cache.ConfigBy[key]) {
+		return cache.NewShardedMapBy[key, string](func(cfg *cache.ConfigBy[key, string]) {
 			cfg.TimeToLive = time.Hour
 			cfg.ShardFunc = func(k key) uint64 {
 				return uint64(k.ID)
@@ -581,7 +604,7 @@ func TestFailoverBy_Get_FailedUpdateTTL(t *testing.T) {
 }
 
 func TestFailoverBy_Get_BackgroundUpdate(t *testing.T) {
-	for _, be := range backendsBy[string](func(config *cache.Config) {
+	for _, be := range backendsBy[string](func(config *cache.Policy) {
 		config.TimeToLive = time.Millisecond
 		config.ExpirationJitter = -1
 	}) {
@@ -631,7 +654,7 @@ func TestFailoverBy_Get_BackgroundUpdate(t *testing.T) {
 }
 
 func TestFailoverBy_Get_BackgroundUpdateMaxExpiration(t *testing.T) {
-	for _, be := range backendsBy[string](func(config *cache.Config) {
+	for _, be := range backendsBy[string](func(config *cache.Policy) {
 		config.TimeToLive = time.Millisecond
 		config.ExpirationJitter = -1
 	}) {
@@ -670,7 +693,7 @@ func TestFailoverBy_Get_BackgroundUpdateMaxExpiration(t *testing.T) {
 }
 
 func TestFailoverBy_Get_SyncUpdate(t *testing.T) {
-	for _, be := range backendsBy[string](func(config *cache.Config) {
+	for _, be := range backendsBy[string](func(config *cache.Policy) {
 		config.TimeToLive = time.Millisecond
 		config.ExpirationJitter = -1
 	}) {
@@ -710,7 +733,7 @@ func TestFailoverBy_Get_SyncUpdate(t *testing.T) {
 func TestFailoverBy_Get_staleBlock(t *testing.T) {
 	st := &stats.TrackerMock{}
 
-	for _, be := range backendsBy[int](func(config *cache.Config) {
+	for _, be := range backendsBy[int](func(config *cache.Policy) {
 		config.Stats = st
 	}) {
 		be := be
@@ -780,7 +803,7 @@ func TestFailoverBy_Get_staleBlock(t *testing.T) {
 func TestFailoverBy_Get_staleValue(t *testing.T) {
 	st := &stats.TrackerMock{}
 
-	for _, be := range backendsBy[int](func(config *cache.Config) {
+	for _, be := range backendsBy[int](func(config *cache.Policy) {
 		config.Stats = st
 	}) {
 		be := be
@@ -880,7 +903,7 @@ func TestFailoverBy_Get_updateErr(t *testing.T) {
 func TestFailoverBy_Get_misses(t *testing.T) {
 	st := &stats.TrackerMock{}
 
-	for _, be := range backendsBy[int](func(config *cache.Config) {
+	for _, be := range backendsBy[int](func(config *cache.Policy) {
 		config.Stats = st
 	}) {
 		be := be
@@ -928,7 +951,7 @@ func TestFailoverBy_Get_misses(t *testing.T) {
 }
 
 func TestFailoverBy_Get_alwaysFail(t *testing.T) {
-	for _, be := range backendsBy[int](func(config *cache.Config) {
+	for _, be := range backendsBy[int](func(config *cache.Policy) {
 		config.TimeToLive = time.Minute
 	}) {
 		be := be

--- a/by_internal_go1.18_test.go
+++ b/by_internal_go1.18_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func backendsByInternal[V any](options ...func(*Config)) []interface {
+func backendsByInternal[V any](options ...func(*Policy)) []interface {
 	ReadWriterBy[string, V]
 	Len() int
 } {
@@ -23,12 +23,16 @@ func backendsByInternal[V any](options ...func(*Config)) []interface {
 		ReadWriterBy[string, V]
 		Len() int
 	}{
-		NewShardedMapBy[string, V](func(cfg *ConfigBy[string]) {
+		NewShardedMapBy[string, V](func(cfg *ConfigBy[string, V]) {
 			for _, option := range options {
-				option(&cfg.Config)
+				option(&cfg.Policy)
 			}
 		}),
-		NewSyncMapBy[string, V](options...),
+		NewSyncMapBy[string, V](func(cfg *ConfigBy[string, V]) {
+			for _, option := range options {
+				option(&cfg.Policy)
+			}
+		}),
 	}
 }
 
@@ -39,10 +43,10 @@ type evictInterfaceBy[V any] interface {
 }
 
 func TestBy_evictHeapInuse(t *testing.T) {
-	for _, be := range backendsByInternal[int](Config{
-		HeapInUseSoftLimit: 1,
-		ExpirationJitter:   -1,
-	}.Use) {
+	for _, be := range backendsByInternal[int](func(cfg *Policy) {
+		cfg.HeapInUseSoftLimit = 1
+		cfg.ExpirationJitter = -1
+	}) {
 		m, ok := be.(evictInterfaceBy[int])
 		require.True(t, ok)
 
@@ -81,10 +85,10 @@ func TestBy_evictHeapInuse(t *testing.T) {
 }
 
 func TestBy_evictHeapInuse_noTTL(t *testing.T) {
-	for _, be := range backendsByInternal[int](Config{
-		HeapInUseSoftLimit: 1,
-		ExpirationJitter:   -1,
-	}.Use) {
+	for _, be := range backendsByInternal[int](func(cfg *Policy) {
+		cfg.HeapInUseSoftLimit = 1
+		cfg.ExpirationJitter = -1
+	}) {
 		m, ok := be.(evictInterfaceBy[int])
 		require.True(t, ok)
 

--- a/config.go
+++ b/config.go
@@ -2,8 +2,8 @@ package cache
 
 import "time"
 
-// Config controls cache instance.
-type Config struct {
+// Policy contains shared cache behavior, expiration, eviction, and observability settings.
+type Policy struct {
 	// Logger is an instance of contextualized logger, can be nil.
 	Logger Logger
 
@@ -60,6 +60,11 @@ type Config struct {
 
 	// EvictionStrategy is EvictMostExpired by default.
 	EvictionStrategy EvictionStrategy
+}
+
+// Config controls []byte -> any cache instances.
+type Config struct {
+	Policy
 
 	// OnDelete is called when an entry is removed from cache by Delete, DeleteAll, expiration cleanup, or eviction.
 	OnDelete func(key []byte, value interface{})
@@ -86,4 +91,11 @@ const (
 // Use is a functional option to apply configuration.
 func (c Config) Use(cfg *Config) {
 	*cfg = c
+}
+
+// WithPolicy applies shared policy to []byte -> any cache configuration.
+func WithPolicy(policy Policy) func(*Config) {
+	return func(cfg *Config) {
+		cfg.Policy = policy
+	}
 }

--- a/config_by_go1.18.go
+++ b/config_by_go1.18.go
@@ -4,15 +4,26 @@
 package cache
 
 // ConfigBy controls typed-key cache instances.
-type ConfigBy[K comparable] struct {
-	Config
+type ConfigBy[K comparable, V any] struct {
+	Policy
 
 	// ShardFunc customizes shard selection in ShardedMapBy.
 	// If nil, a default sharder is used for supported key kinds.
 	ShardFunc func(K) uint64
+
+	// OnDeleteBy is called when an entry is removed from a typed-key cache by Delete,
+	// DeleteAll, expiration cleanup, or eviction.
+	OnDeleteBy func(key K, value V)
 }
 
 // Use is a functional option to apply keyed configuration.
-func (c ConfigBy[K]) Use(cfg *ConfigBy[K]) {
+func (c ConfigBy[K, V]) Use(cfg *ConfigBy[K, V]) {
 	*cfg = c
+}
+
+// WithPolicyBy applies shared policy to typed-key cache configuration.
+func WithPolicyBy[K comparable, V any](policy Policy) func(*ConfigBy[K, V]) {
+	return func(cfg *ConfigBy[K, V]) {
+		cfg.Policy = policy
+	}
 }

--- a/config_of_go1.18.go
+++ b/config_of_go1.18.go
@@ -1,0 +1,24 @@
+//go:build go1.18
+// +build go1.18
+
+package cache
+
+// ConfigOf controls []byte-keyed typed-value cache instances.
+type ConfigOf[V any] struct {
+	Policy
+
+	// OnDelete is called when an entry is removed from cache by Delete, DeleteAll, expiration cleanup, or eviction.
+	OnDelete func(key []byte, value V)
+}
+
+// Use is a functional option to apply typed-value configuration.
+func (c ConfigOf[V]) Use(cfg *ConfigOf[V]) {
+	*cfg = c
+}
+
+// WithPolicyOf applies shared policy to []byte-keyed typed-value cache configuration.
+func WithPolicyOf[V any](policy Policy) func(*ConfigOf[V]) {
+	return func(cfg *ConfigOf[V]) {
+		cfg.Policy = policy
+	}
+}

--- a/evict_go1.18_test.go
+++ b/evict_go1.18_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func backendsOf[V any](options ...func(*Config)) []interface {
+func backendsOf[V any](options ...func(*Policy)) []interface {
 	ReadWriterOf[V]
 	Len() int
 } {
@@ -24,7 +24,11 @@ func backendsOf[V any](options ...func(*Config)) []interface {
 		ReadWriterOf[V]
 		Len() int
 	}{
-		NewShardedMapOf[V](options...),
+		NewShardedMapOf[V](func(cfg *ConfigOf[V]) {
+			for _, option := range options {
+				option(&cfg.Policy)
+			}
+		}),
 	}
 }
 
@@ -40,10 +44,10 @@ type evictInterfaceOf[V any] interface {
 }
 
 func Test_evictHeapInuse(t *testing.T) {
-	for _, be := range backendsOf[int](Config{
-		HeapInUseSoftLimit: 1, // Setting heap threshold to 1B to force eviction.
-		ExpirationJitter:   -1,
-	}.Use) {
+	for _, be := range backendsOf[int](func(cfg *Policy) {
+		cfg.HeapInUseSoftLimit = 1 // Setting heap threshold to 1B to force eviction.
+		cfg.ExpirationJitter = -1
+	}) {
 		m, ok := be.(evictInterfaceOf[int])
 
 		require.True(t, ok)
@@ -86,10 +90,10 @@ func Test_evictHeapInuse(t *testing.T) {
 }
 
 func Test_evictHeapInuse_disabled(t *testing.T) {
-	for _, be := range backendsOf[int](Config{
-		HeapInUseSoftLimit: 0, // Setting heap threshold to 0 to disable eviction.
-		ExpirationJitter:   -1,
-	}.Use) {
+	for _, be := range backendsOf[int](func(cfg *Policy) {
+		cfg.HeapInUseSoftLimit = 0 // Setting heap threshold to 0 to disable eviction.
+		cfg.ExpirationJitter = -1
+	}) {
 		m, ok := be.(evictInterfaceOf[int])
 
 		require.True(t, ok)
@@ -109,10 +113,10 @@ func Test_evictHeapInuse_disabled(t *testing.T) {
 }
 
 func Test_evictHeapInuse_skipped(t *testing.T) {
-	for _, be := range backendsOf[int](Config{
-		HeapInUseSoftLimit: 1e10, // Setting heap threshold to big value to skip eviction.
-		ExpirationJitter:   -1,
-	}.Use) {
+	for _, be := range backendsOf[int](func(cfg *Policy) {
+		cfg.HeapInUseSoftLimit = 1e10 // Setting heap threshold to big value to skip eviction.
+		cfg.ExpirationJitter = -1
+	}) {
 		m, ok := be.(evictInterfaceOf[int])
 
 		require.True(t, ok)
@@ -132,9 +136,9 @@ func Test_evictHeapInuse_skipped(t *testing.T) {
 }
 
 func Test_evictHeapInuse_concurrency(t *testing.T) {
-	for _, be := range backendsOf[int](Config{
-		HeapInUseSoftLimit: 1, // Setting heap threshold to 1B value to force eviction.
-	}.Use) {
+	for _, be := range backendsOf[int](func(cfg *Policy) {
+		cfg.HeapInUseSoftLimit = 1 // Setting heap threshold to 1B value to force eviction.
+	}) {
 		m, ok := be.(evictInterfaceOf[int])
 
 		require.True(t, ok)
@@ -163,10 +167,10 @@ func Test_evictHeapInuse_concurrency(t *testing.T) {
 }
 
 func Test_evictHeapInuse_noTTL(t *testing.T) {
-	for _, be := range backendsOf[int](Config{
-		HeapInUseSoftLimit: 1, // Setting heap threshold to 1B to force eviction.
-		ExpirationJitter:   -1,
-	}.Use) {
+	for _, be := range backendsOf[int](func(cfg *Policy) {
+		cfg.HeapInUseSoftLimit = 1 // Setting heap threshold to 1B to force eviction.
+		cfg.ExpirationJitter = -1
+	}) {
 		m, ok := be.(evictInterfaceOf[int])
 
 		require.True(t, ok)
@@ -209,7 +213,7 @@ func Test_evictHeapInuse_noTTL(t *testing.T) {
 }
 
 func Test_generic_LFU_eviction(t *testing.T) {
-	for _, c := range backendsOf[int](func(cfg *Config) {
+	for _, c := range backendsOf[int](func(cfg *Policy) {
 		cfg.EvictionStrategy = EvictLeastFrequentlyUsed
 		cfg.EvictFraction = 0.5
 		cfg.CountSoftLimit = 100
@@ -268,7 +272,7 @@ func Test_generic_LFU_eviction(t *testing.T) {
 }
 
 func Test_generic_LRU_eviction(t *testing.T) {
-	for _, c := range backendsOf[int](func(cfg *Config) {
+	for _, c := range backendsOf[int](func(cfg *Policy) {
 		cfg.EvictionStrategy = EvictLeastRecentlyUsed
 		cfg.EvictFraction = 0.5
 		cfg.CountSoftLimit = 100

--- a/evict_test.go
+++ b/evict_test.go
@@ -40,8 +40,10 @@ type evictInterface interface {
 
 func TestShardedMap_evictHeapInuse(t *testing.T) {
 	for _, be := range backends(Config{
-		HeapInUseSoftLimit: 1, // Setting heap threshold to 1B to force eviction.
-		ExpirationJitter:   -1,
+		Policy: Policy{
+			HeapInUseSoftLimit: 1, // Setting heap threshold to 1B to force eviction.
+			ExpirationJitter:   -1,
+		},
 	}.Use) {
 		m, ok := be.(evictInterface)
 
@@ -86,8 +88,10 @@ func TestShardedMap_evictHeapInuse(t *testing.T) {
 
 func TestShardedMap_evictHeapInuse_disabled(t *testing.T) {
 	for _, be := range backends(Config{
-		HeapInUseSoftLimit: 0, // Setting heap threshold to 0 to disable eviction.
-		ExpirationJitter:   -1,
+		Policy: Policy{
+			HeapInUseSoftLimit: 0, // Setting heap threshold to 0 to disable eviction.
+			ExpirationJitter:   -1,
+		},
 	}.Use) {
 		m, ok := be.(evictInterface)
 
@@ -109,8 +113,10 @@ func TestShardedMap_evictHeapInuse_disabled(t *testing.T) {
 
 func TestShardedMap_evictHeapInuse_skipped(t *testing.T) {
 	for _, be := range backends(Config{
-		HeapInUseSoftLimit: 1e10, // Setting heap threshold to big value to skip eviction.
-		ExpirationJitter:   -1,
+		Policy: Policy{
+			HeapInUseSoftLimit: 1e10, // Setting heap threshold to big value to skip eviction.
+			ExpirationJitter:   -1,
+		},
 	}.Use) {
 		m, ok := be.(evictInterface)
 
@@ -132,7 +138,9 @@ func TestShardedMap_evictHeapInuse_skipped(t *testing.T) {
 
 func TestShardedMap_evictHeapInuse_concurrency(t *testing.T) {
 	for _, be := range backends(Config{
-		HeapInUseSoftLimit: 1, // Setting heap threshold to 1B value to force eviction.
+		Policy: Policy{
+			HeapInUseSoftLimit: 1, // Setting heap threshold to 1B value to force eviction.
+		},
 	}.Use) {
 		m, ok := be.(evictInterface)
 
@@ -163,8 +171,10 @@ func TestShardedMap_evictHeapInuse_concurrency(t *testing.T) {
 
 func TestShardedMap_evictHeapInuse_noTTL(t *testing.T) {
 	for _, be := range backends(Config{
-		HeapInUseSoftLimit: 1, // Setting heap threshold to 1B to force eviction.
-		ExpirationJitter:   -1,
+		Policy: Policy{
+			HeapInUseSoftLimit: 1, // Setting heap threshold to 1B to force eviction.
+			ExpirationJitter:   -1,
+		},
 	}.Use) {
 		m, ok := be.(evictInterface)
 

--- a/example_go1.18_test.go
+++ b/example_go1.18_test.go
@@ -19,20 +19,22 @@ func ExampleNewShardedMapOf() {
 	}
 
 	// Create cache instance.
-	c := cache.NewShardedMapOf[Dog](cache.Config{
-		Name:       "dogs",
-		TimeToLive: 13 * time.Minute,
-		// Logging errors with standard logger, non-error messages are ignored.
-		Logger: cache.NewLogger(func(ctx context.Context, msg string, keysAndValues ...interface{}) {
-			log.Printf("cache failed: %s %v", msg, keysAndValues)
-		}, nil, nil, nil),
+	c := cache.NewShardedMapOf[Dog](cache.ConfigOf[Dog]{
+		Policy: cache.Policy{
+			Name:       "dogs",
+			TimeToLive: 13 * time.Minute,
+			// Logging errors with standard logger, non-error messages are ignored.
+			Logger: cache.NewLogger(func(ctx context.Context, msg string, keysAndValues ...interface{}) {
+				log.Printf("cache failed: %s %v", msg, keysAndValues)
+			}, nil, nil, nil),
 
-		// Tweak these parameters to reduce/stabilize rwMutexMap consumption at cost of cache hit rate.
-		// If cache cardinality and size are reasonable, default values should be fine.
-		DeleteExpiredAfter:       time.Hour,
-		DeleteExpiredJobInterval: 10 * time.Minute,
-		HeapInUseSoftLimit:       200 * 1024 * 1024, // 200MB soft limit for process heap in use.
-		EvictFraction:            0.2,               // Drop 20% of mostly expired items (including non-expired) on heap overuse.
+			// Tweak these parameters to reduce/stabilize rwMutexMap consumption at cost of cache hit rate.
+			// If cache cardinality and size are reasonable, default values should be fine.
+			DeleteExpiredAfter:       time.Hour,
+			DeleteExpiredJobInterval: 10 * time.Minute,
+			HeapInUseSoftLimit:       200 * 1024 * 1024, // 200MB soft limit for process heap in use.
+			EvictFraction:            0.2,               // Drop 20% of mostly expired items (including non-expired) on heap overuse.
+		},
 	}.Use)
 
 	// Use context if available, it may hold TTL and SkipRead information.

--- a/example_test.go
+++ b/example_test.go
@@ -12,19 +12,21 @@ import (
 func ExampleNewShardedMap() {
 	// Create cache instance.
 	c := cache.NewShardedMap(cache.Config{
-		Name:       "dogs",
-		TimeToLive: 13 * time.Minute,
-		// Logging errors with standard logger, non-error messages are ignored.
-		Logger: cache.NewLogger(func(ctx context.Context, msg string, keysAndValues ...interface{}) {
-			log.Printf("cache failed: %s %v", msg, keysAndValues)
-		}, nil, nil, nil),
+		Policy: cache.Policy{
+			Name:       "dogs",
+			TimeToLive: 13 * time.Minute,
+			// Logging errors with standard logger, non-error messages are ignored.
+			Logger: cache.NewLogger(func(ctx context.Context, msg string, keysAndValues ...interface{}) {
+				log.Printf("cache failed: %s %v", msg, keysAndValues)
+			}, nil, nil, nil),
 
-		// Tweak these parameters to reduce/stabilize rwMutexMap consumption at cost of cache hit rate.
-		// If cache cardinality and size are reasonable, default values should be fine.
-		DeleteExpiredAfter:       time.Hour,
-		DeleteExpiredJobInterval: 10 * time.Minute,
-		HeapInUseSoftLimit:       200 * 1024 * 1024, // 200MB soft limit for process heap in use.
-		EvictFraction:            0.2,               // Drop 20% of mostly expired items (including non-expired) on heap overuse.
+			// Tweak these parameters to reduce/stabilize rwMutexMap consumption at cost of cache hit rate.
+			// If cache cardinality and size are reasonable, default values should be fine.
+			DeleteExpiredAfter:       time.Hour,
+			DeleteExpiredJobInterval: 10 * time.Minute,
+			HeapInUseSoftLimit:       200 * 1024 * 1024, // 200MB soft limit for process heap in use.
+			EvictFraction:            0.2,               // Drop 20% of mostly expired items (including non-expired) on heap overuse.
+		},
 	}.Use)
 
 	// Use context if available, it may hold TTL and SkipRead information.

--- a/failover.go
+++ b/failover.go
@@ -122,14 +122,16 @@ func NewFailover(options ...func(cfg *FailoverConfig)) *Failover {
 
 	if cfg.FailedUpdateTTL > -1 {
 		f.Errors = NewShardedMap(Config{
-			Name:       "err_" + cfg.Name,
-			Logger:     cfg.Logger,
-			Stats:      cfg.Stats,
-			TimeToLive: cfg.FailedUpdateTTL,
+			Policy: Policy{
+				Name:       "err_" + cfg.Name,
+				Logger:     cfg.Logger,
+				Stats:      cfg.Stats,
+				TimeToLive: cfg.FailedUpdateTTL,
 
-			// Short cleanup intervals to avoid storing potentially heavy errors for long time.
-			DeleteExpiredAfter:       time.Minute,
-			DeleteExpiredJobInterval: time.Minute,
+				// Short cleanup intervals to avoid storing potentially heavy errors for long time.
+				DeleteExpiredAfter:       time.Minute,
+				DeleteExpiredJobInterval: time.Minute,
+			},
 		}.Use)
 	}
 

--- a/failover_by_go1.18.go
+++ b/failover_by_go1.18.go
@@ -21,7 +21,7 @@ type FailoverConfigBy[K comparable, V any] struct {
 	Backend ReadWriterBy[K, V]
 
 	// BackendConfig is a configuration for ShardedMapBy cache instance if Backend is not provided.
-	BackendConfig ConfigBy[K]
+	BackendConfig ConfigBy[K, V]
 
 	// FailedUpdateTTL is ttl of failed build cache, default 20s, -1 disables errors cache.
 	FailedUpdateTTL time.Duration
@@ -103,8 +103,8 @@ func NewFailoverBy[K comparable, V any](options ...func(cfg *FailoverConfigBy[K,
 	f.wr, _ = f.backend.(WriteAndReaderBy[K, V])
 
 	if cfg.FailedUpdateTTL > -1 {
-		f.Errors = NewShardedMapBy[K, error](ConfigBy[K]{
-			Config: Config{
+		f.Errors = NewShardedMapBy[K, error](ConfigBy[K, error]{
+			Policy: Policy{
 				Name:       "err_" + cfg.Name,
 				Logger:     cfg.Logger,
 				Stats:      cfg.Stats,

--- a/failover_go1.18.go
+++ b/failover_go1.18.go
@@ -21,7 +21,7 @@ type FailoverConfigOf[V any] struct {
 	Backend ReadWriterOf[V]
 
 	// BackendConfig is a configuration for ShardedMap cache instance if Backend is not provided.
-	BackendConfig Config
+	BackendConfig ConfigOf[V]
 
 	// FailedUpdateTTL is ttl of failed build cache, default 20s, -1 disables errors cache.
 	FailedUpdateTTL time.Duration
@@ -111,15 +111,17 @@ func NewFailoverOf[V any](options ...func(cfg *FailoverConfigOf[V])) *FailoverOf
 	f.wr, _ = f.backend.(WriteAndReaderOf[V])
 
 	if cfg.FailedUpdateTTL > -1 {
-		f.Errors = NewShardedMapOf[error](Config{
-			Name:       "err_" + cfg.Name,
-			Logger:     cfg.Logger,
-			Stats:      cfg.Stats,
-			TimeToLive: cfg.FailedUpdateTTL,
+		f.Errors = NewShardedMapOf[error](ConfigOf[error]{
+			Policy: Policy{
+				Name:       "err_" + cfg.Name,
+				Logger:     cfg.Logger,
+				Stats:      cfg.Stats,
+				TimeToLive: cfg.FailedUpdateTTL,
 
-			// Short cleanup intervals to avoid storing potentially heavy errors for long time.
-			DeleteExpiredAfter:       time.Minute,
-			DeleteExpiredJobInterval: time.Minute,
+				// Short cleanup intervals to avoid storing potentially heavy errors for long time.
+				DeleteExpiredAfter:       time.Minute,
+				DeleteExpiredJobInterval: time.Minute,
+			},
 		}.Use)
 	}
 

--- a/failover_test.go
+++ b/failover_test.go
@@ -203,8 +203,10 @@ func TestFailover_Get_BackgroundUpdate(t *testing.T) {
 				cache.FailoverConfig{
 					Logger: logger,
 					BackendConfig: cache.Config{
-						TimeToLive:       time.Millisecond,
-						ExpirationJitter: -1,
+						Policy: cache.Policy{
+							TimeToLive:       time.Millisecond,
+							ExpirationJitter: -1,
+						},
 					},
 					SyncRead: true,
 				}.Use,

--- a/filecache/config_go1.18.go
+++ b/filecache/config_go1.18.go
@@ -44,7 +44,10 @@ func PrefixSplit(lengths ...int) func(version string) []string {
 				break
 			}
 
-			end := min(pos+n, len(version))
+			end := pos + n
+			if end > len(version) {
+				end = len(version)
+			}
 
 			segments = append(segments, version[pos:end])
 			pos = end

--- a/filecache/config_go1.18.go
+++ b/filecache/config_go1.18.go
@@ -3,12 +3,18 @@
 
 package filecache
 
-import "github.com/bool64/cache"
+import (
+	"github.com/bool64/cache"
+	"github.com/bool64/cache/blob"
+)
 
 // Config controls file-backed storage layout and index behavior.
 type Config[K comparable] struct {
 	// IndexPolicy configures the in-memory index backend.
 	IndexPolicy cache.Policy
+
+	// RetentionPolicy configures blob-storage retention and eviction behavior.
+	blob.RetentionPolicy
 
 	// IndexShardFunc customizes shard selection in the typed in-memory index.
 	IndexShardFunc func(K) uint64
@@ -38,10 +44,7 @@ func PrefixSplit(lengths ...int) func(version string) []string {
 				break
 			}
 
-			end := pos + n
-			if end > len(version) {
-				end = len(version)
-			}
+			end := min(pos+n, len(version))
 
 			segments = append(segments, version[pos:end])
 			pos = end

--- a/filecache/config_go1.18.go
+++ b/filecache/config_go1.18.go
@@ -1,0 +1,52 @@
+//go:build go1.18
+// +build go1.18
+
+package filecache
+
+import "github.com/bool64/cache"
+
+// Config controls file-backed storage layout and index behavior.
+type Config[K comparable] struct {
+	// IndexPolicy configures the in-memory index backend.
+	IndexPolicy cache.Policy
+
+	// IndexShardFunc customizes shard selection in the typed in-memory index.
+	IndexShardFunc func(K) uint64
+
+	// SplitPath converts a version into nested path segments under data dir.
+	// If nil, two 2-character prefix directories are used.
+	SplitPath func(version string) []string
+}
+
+// Use is a functional option to apply storage configuration.
+func (c Config[K]) Use(cfg *Config[K]) {
+	*cfg = c
+}
+
+// PrefixSplit creates a version path splitter that uses consecutive prefix lengths
+// as nested directory names. For example PrefixSplit(1) uses the first character,
+// and PrefixSplit(2, 2) matches the default layout.
+func PrefixSplit(lengths ...int) func(version string) []string {
+	cp := append([]int(nil), lengths...)
+
+	return func(version string) []string {
+		segments := make([]string, 0, len(cp))
+		pos := 0
+
+		for _, n := range cp {
+			if n <= 0 || pos >= len(version) {
+				break
+			}
+
+			end := pos + n
+			if end > len(version) {
+				end = len(version)
+			}
+
+			segments = append(segments, version[pos:end])
+			pos = end
+		}
+
+		return segments
+	}
+}

--- a/filecache/example_test.go
+++ b/filecache/example_test.go
@@ -23,7 +23,7 @@ func ExampleFailover() {
 
 	defer os.RemoveAll(dir)
 
-	st, err := filecache.NewStorage(dir)
+	st, err := filecache.NewStorage[string](dir)
 	if err != nil {
 		panic(err)
 	}
@@ -32,11 +32,11 @@ func ExampleFailover() {
 		_ = st.Close()
 	}()
 
-	f := cache.NewFailoverOf[blob.Entry](func(cfg *cache.FailoverConfigOf[blob.Entry]) {
+	f := cache.NewFailoverBy[string, blob.Entry](func(cfg *cache.FailoverConfigBy[string, blob.Entry]) {
 		cfg.Backend = st
 	})
 
-	entry, err := f.Get(ctx, []byte("photo:1"), func(ctx context.Context) (blob.Entry, error) {
+	entry, err := f.Get(ctx, "photo:1", func(ctx context.Context) (blob.Entry, error) {
 		return blob.FromReader(bytes.NewBufferString("hello blob"), blob.Meta{
 			Name: "photo.txt",
 		}), nil

--- a/filecache/failover_integration_go1.18_test.go
+++ b/filecache/failover_integration_go1.18_test.go
@@ -19,20 +19,20 @@ import (
 func TestFailoverOf_blobEntry_returnsStoredEntryForOneShotSource(t *testing.T) {
 	dir := t.TempDir()
 
-	st, err := filecache.NewStorage(dir)
+	st, err := filecache.NewStorage[string](dir)
 	require.NoError(t, err)
 
 	defer func() {
 		require.NoError(t, st.Close())
 	}()
 
-	f := cache.NewFailoverOf[blob.Entry](func(cfg *cache.FailoverConfigOf[blob.Entry]) {
+	f := cache.NewFailoverBy[string, blob.Entry](func(cfg *cache.FailoverConfigBy[string, blob.Entry]) {
 		cfg.Backend = st
 	})
 
 	ctx := context.Background()
 
-	entry, err := f.Get(ctx, []byte("photo:1"), func(ctx context.Context) (blob.Entry, error) {
+	entry, err := f.Get(ctx, "photo:1", func(ctx context.Context) (blob.Entry, error) {
 		return blob.FromReader(bytes.NewBufferString("hello"), blob.Meta{Name: "photo.txt"}), nil
 	})
 	require.NoError(t, err)

--- a/filecache/storage_go1.18.go
+++ b/filecache/storage_go1.18.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -207,7 +208,7 @@ func (s *Storage[K]) WriteAndRead(ctx context.Context, key K, entry blob.Entry) 
 		}
 
 		if rmErr := os.Remove(tmpName); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
-			err = errors.Join(err, rmErr)
+			err = joinErr(err, rmErr)
 		}
 	}()
 
@@ -399,9 +400,15 @@ func (s *Storage[K]) storedBytesOverflow() bool {
 	}
 
 	total := atomic.LoadInt64(&s.bytes)
-	total = max(total, 0)
+	if total < 0 {
+		total = 0
+	}
 
-	return uint64(total) > s.limit
+	if s.limit > math.MaxInt64 {
+		return false
+	}
+
+	return total > int64(s.limit)
 }
 
 func (s *Storage[K]) addStoredBytes(delta int64) {
@@ -530,5 +537,17 @@ func (t *trackedFile) Close() error {
 		}
 	})
 
-	return errors.Join(err, t.relErr)
+	return joinErr(err, t.relErr)
+}
+
+func joinErr(err error, other error) error {
+	if err == nil {
+		return other
+	}
+
+	if other == nil {
+		return err
+	}
+
+	return fmt.Errorf("%v: %w", err, other)
 }

--- a/filecache/storage_go1.18.go
+++ b/filecache/storage_go1.18.go
@@ -39,6 +39,8 @@ type Storage[K comparable] struct {
 	dataDir string
 
 	index *cache.ShardedMapBy[K, storedEntry]
+	log   cache.Logger
+	split func(version string) []string
 
 	mu          sync.Mutex
 	openedFiles map[string]*openedFile
@@ -71,10 +73,30 @@ func (b *blobInstance) Open() (io.ReadCloser, error) {
 }
 
 // NewStorage creates a local filesystem-backed blob storage.
-func NewStorage[K comparable](path string) (*Storage[K], error) {
+func NewStorage[K comparable](path string, options ...func(cfg *Config[K])) (*Storage[K], error) {
+	cfg := Config[K]{}
+
+	for _, option := range options {
+		option(&cfg)
+	}
+
+	if cfg.IndexPolicy.Name == "" {
+		cfg.IndexPolicy.Name = "filecache:" + filepath.Base(path)
+	}
+
+	if cfg.IndexPolicy.TimeToLive == 0 {
+		cfg.IndexPolicy.TimeToLive = cache.UnlimitedTTL
+	}
+
+	if cfg.SplitPath == nil {
+		cfg.SplitPath = PrefixSplit(2, 2)
+	}
+
 	s := &Storage[K]{
 		dir:         path,
 		dataDir:     filepath.Join(path, dataDirName),
+		log:         cfg.IndexPolicy.Logger,
+		split:       cfg.SplitPath,
 		openedFiles: make(map[string]*openedFile),
 	}
 
@@ -82,17 +104,22 @@ func NewStorage[K comparable](path string) (*Storage[K], error) {
 		return nil, err
 	}
 
-	s.index = cache.NewShardedMapBy[K, storedEntry](cache.ConfigBy[K]{
-		Config: cache.Config{
-			Name:       "filecache:" + filepath.Base(path),
-			TimeToLive: cache.UnlimitedTTL,
-			OnDelete: func(_ []byte, value interface{}) {
-				if entry, ok := value.(storedEntry); ok {
-					s.markDead(entry.Version)
+	s.index = cache.NewShardedMapBy[K, storedEntry](
+		cache.WithPolicyBy[K, storedEntry](cfg.IndexPolicy),
+		func(indexCfg *cache.ConfigBy[K, storedEntry]) {
+			indexCfg.ShardFunc = cfg.IndexShardFunc
+			indexCfg.OnDeleteBy = func(_ K, entry storedEntry) {
+				if rmErr := s.removeVersion(entry.Version); rmErr != nil && s.log != nil {
+					s.log.Error(context.Background(), "failed to delete blob file after index removal",
+						"error", rmErr,
+						"version", entry.Version,
+						"path", s.pathForVersion(entry.Version),
+						"name", cfg.IndexPolicy.Name,
+					)
 				}
-			},
+			}
 		},
-	}.Use)
+	)
 
 	if err := s.restoreIndex(); err != nil {
 		s.index = nil
@@ -156,23 +183,25 @@ func (s *Storage[K]) WriteAndRead(ctx context.Context, key K, entry blob.Entry) 
 	tmpName := tmp.Name()
 
 	defer func() {
-		if clErr := tmp.Close(); clErr != nil && err == nil {
-			err = clErr
+		if tmp != nil {
+			if clErr := tmp.Close(); clErr != nil && err == nil {
+				err = clErr
+			}
 		}
-		_ = os.Remove(tmpName)
+
+		if rmErr := os.Remove(tmpName); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
+			err = errors.Join(err, rmErr)
+		}
 	}()
 
 	if _, err := io.Copy(tmp, rc); err != nil {
 		return nil, err
 	}
 
-	if err := rc.Close(); err != nil {
-		return nil, err
-	}
-
 	if err := tmp.Close(); err != nil {
 		return nil, err
 	}
+	tmp = nil
 
 	if err := os.Rename(tmpName, finalPath); err != nil {
 		return nil, err
@@ -207,16 +236,7 @@ func (s *Storage[K]) WriteAndRead(ctx context.Context, key K, entry blob.Entry) 
 
 // Delete deletes a blob entry by key.
 func (s *Storage[K]) Delete(ctx context.Context, key K) error {
-	v, ok := s.currentEntry(ctx, key)
-	err := s.index.Delete(ctx, key)
-
-	if ok && err == nil {
-		if !s.markDead(v.Version) {
-			_ = os.Remove(s.pathForVersion(v.Version))
-		}
-	}
-
-	return err
+	return s.index.Delete(ctx, key)
 }
 
 // Close dumps the in-memory index and stops background jobs.
@@ -252,20 +272,20 @@ func (s *Storage[K]) openVersion(version string) (io.ReadCloser, error) {
 	//nolint:gosec // Path is derived from internal versioned storage layout, not external input.
 	f, err := os.Open(s.pathForVersion(version))
 	if err != nil {
-		s.releaseVersion(version)
+		_ = s.releaseVersion(version)
 
 		return nil, err
 	}
 
 	return &trackedFile{
 		File: f,
-		release: func() {
-			s.releaseVersion(version)
+		release: func() error {
+			return s.releaseVersion(version)
 		},
 	}, nil
 }
 
-func (s *Storage[K]) releaseVersion(version string) {
+func (s *Storage[K]) releaseVersion(version string) error {
 	defer s.openedWait.Done()
 
 	s.mu.Lock()
@@ -276,16 +296,22 @@ func (s *Storage[K]) releaseVersion(version string) {
 	s.mu.Unlock()
 
 	if rt == nil {
-		return
+		return nil
 	}
 
 	if rt.refs == 0 && rt.dead {
-		_ = os.Remove(s.pathForVersion(version))
+		err := os.Remove(s.pathForVersion(version))
 
 		s.mu.Lock()
 		delete(s.openedFiles, version)
 		s.mu.Unlock()
+
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
 	}
+
+	return nil
 }
 
 func (s *Storage[K]) acquireVersion(version string) *openedFile {
@@ -324,6 +350,18 @@ func (s *Storage[K]) markDead(version string) bool {
 	return true
 }
 
+func (s *Storage[K]) removeVersion(version string) error {
+	if s.markDead(version) {
+		return nil
+	}
+
+	if err := os.Remove(s.pathForVersion(version)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	return nil
+}
+
 func (s *Storage[K]) restoreIndex() (err error) {
 	f, err := os.Open(filepath.Join(s.dir, indexFileName))
 	if err != nil {
@@ -351,7 +389,13 @@ func (s *Storage[K]) dumpIndex() (err error) {
 
 	tmpName := tmp.Name()
 	defer func() {
-		if rmErr := os.Remove(tmpName); rmErr != nil && err == nil {
+		if tmp != nil {
+			if clErr := tmp.Close(); clErr != nil && err == nil {
+				err = clErr
+			}
+		}
+
+		if rmErr := os.Remove(tmpName); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) && err == nil {
 			err = rmErr
 		}
 	}()
@@ -364,18 +408,22 @@ func (s *Storage[K]) dumpIndex() (err error) {
 	if err := tmp.Close(); err != nil {
 		return err
 	}
+	tmp = nil
 
 	return os.Rename(tmpName, filepath.Join(s.dir, indexFileName))
 }
 
 func (s *Storage[K]) pathForVersion(version string) string {
 	path := s.dataDir
-	if len(version) >= 2 {
-		path = filepath.Join(path, version[:2])
-	}
 
-	if len(version) >= 4 {
-		path = filepath.Join(path, version[2:4])
+	if s.split != nil {
+		for _, segment := range s.split(version) {
+			if segment == "" {
+				continue
+			}
+
+			path = filepath.Join(path, segment)
+		}
 	}
 
 	return filepath.Join(path, version+fileExt)
@@ -394,16 +442,17 @@ type trackedFile struct {
 	*os.File
 
 	once    sync.Once
-	release func()
+	release func() error
+	relErr  error
 }
 
 func (t *trackedFile) Close() error {
 	err := t.File.Close()
 	t.once.Do(func() {
 		if t.release != nil {
-			t.release()
+			t.relErr = t.release()
 		}
 	})
 
-	return err
+	return errors.Join(err, t.relErr)
 }

--- a/filecache/storage_go1.18.go
+++ b/filecache/storage_go1.18.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bool64/cache"
@@ -29,8 +30,9 @@ const (
 )
 
 var (
-	_ cache.ReadWriterBy[string, blob.Entry]     = (*Storage[string])(nil)
-	_ cache.WriteAndReaderBy[string, blob.Entry] = (*Storage[string])(nil)
+	_     cache.ReadWriterBy[string, blob.Entry]     = (*Storage[string])(nil)
+	_     cache.WriteAndReaderBy[string, blob.Entry] = (*Storage[string])(nil)
+	bgCtx                                            = context.Background()
 )
 
 // Storage is a local filesystem-backed blob storage.
@@ -41,6 +43,8 @@ type Storage[K comparable] struct {
 	index *cache.ShardedMapBy[K, storedEntry]
 	log   cache.Logger
 	split func(version string) []string
+	limit uint64
+	bytes int64
 
 	mu          sync.Mutex
 	openedFiles map[string]*openedFile
@@ -97,6 +101,7 @@ func NewStorage[K comparable](path string, options ...func(cfg *Config[K])) (*St
 		dataDir:     filepath.Join(path, dataDirName),
 		log:         cfg.IndexPolicy.Logger,
 		split:       cfg.SplitPath,
+		limit:       cfg.StoredBytesSoftLimit,
 		openedFiles: make(map[string]*openedFile),
 	}
 
@@ -107,10 +112,20 @@ func NewStorage[K comparable](path string, options ...func(cfg *Config[K])) (*St
 	s.index = cache.NewShardedMapBy[K, storedEntry](
 		cache.WithPolicyBy[K, storedEntry](cfg.IndexPolicy),
 		func(indexCfg *cache.ConfigBy[K, storedEntry]) {
+			origEvictionNeeded := indexCfg.EvictionNeeded
+
+			if s.limit > 0 {
+				indexCfg.EvictionNeeded = func() bool {
+					return s.storedBytesOverflow() || (origEvictionNeeded != nil && origEvictionNeeded())
+				}
+			}
+
 			indexCfg.ShardFunc = cfg.IndexShardFunc
 			indexCfg.OnDeleteBy = func(_ K, entry storedEntry) {
+				s.addStoredBytes(-entry.Meta.Size)
+
 				if rmErr := s.removeVersion(entry.Version); rmErr != nil && s.log != nil {
-					s.log.Error(context.Background(), "failed to delete blob file after index removal",
+					s.log.Error(bgCtx, "failed to delete blob file after index removal",
 						"error", rmErr,
 						"version", entry.Version,
 						"path", s.pathForVersion(entry.Version),
@@ -160,6 +175,7 @@ func (s *Storage[K]) WriteAndRead(ctx context.Context, key K, entry blob.Entry) 
 	if err != nil {
 		return nil, err
 	}
+
 	defer func() {
 		if clErr := rc.Close(); clErr != nil && err == nil {
 			err = clErr
@@ -180,6 +196,7 @@ func (s *Storage[K]) WriteAndRead(ctx context.Context, key K, entry blob.Entry) 
 	if err != nil {
 		return nil, err
 	}
+
 	tmpName := tmp.Name()
 
 	defer func() {
@@ -194,13 +211,15 @@ func (s *Storage[K]) WriteAndRead(ctx context.Context, key K, entry blob.Entry) 
 		}
 	}()
 
-	if _, err := io.Copy(tmp, rc); err != nil {
+	size, err := io.Copy(tmp, rc)
+	if err != nil {
 		return nil, err
 	}
 
 	if err := tmp.Close(); err != nil {
 		return nil, err
 	}
+
 	tmp = nil
 
 	if err := os.Rename(tmpName, finalPath); err != nil {
@@ -211,17 +230,28 @@ func (s *Storage[K]) WriteAndRead(ctx context.Context, key K, entry blob.Entry) 
 		Meta:    entry.Meta(),
 		Version: version,
 	}
+	newEntry.Meta.Size = size
 
 	oldEntry, oldEntryExists := s.currentEntry(ctx, key)
 
 	if err := s.index.Write(ctx, key, newEntry); err != nil {
-		s.markDead(version)
+		_ = s.removeVersion(version)
 
 		return nil, err
 	}
 
+	s.addStoredBytes(newEntry.Meta.Size)
+
 	if oldEntryExists {
-		s.markDead(oldEntry.Version)
+		s.addStoredBytes(-oldEntry.Meta.Size)
+
+		if rmErr := s.removeVersion(oldEntry.Version); rmErr != nil && s.log != nil {
+			s.log.Error(ctx, "failed to delete superseded blob file",
+				"error", rmErr,
+				"version", oldEntry.Version,
+				"path", s.pathForVersion(oldEntry.Version),
+			)
+		}
 	}
 
 	b := blobInstance{
@@ -269,7 +299,6 @@ func (s *Storage[K]) currentEntry(ctx context.Context, key K) (storedEntry, bool
 func (s *Storage[K]) openVersion(version string) (io.ReadCloser, error) {
 	s.acquireVersion(version)
 
-	//nolint:gosec // Path is derived from internal versioned storage layout, not external input.
 	f, err := os.Open(s.pathForVersion(version))
 	if err != nil {
 		_ = s.releaseVersion(version)
@@ -290,9 +319,11 @@ func (s *Storage[K]) releaseVersion(version string) error {
 
 	s.mu.Lock()
 	rt := s.openedFiles[version]
+
 	if rt != nil {
-		rt.refs -= 1
+		rt.refs--
 	}
+
 	s.mu.Unlock()
 
 	if rt == nil {
@@ -322,7 +353,7 @@ func (s *Storage[K]) acquireVersion(version string) *openedFile {
 
 	rt := s.openedFiles[version]
 	if rt != nil {
-		rt.refs += 1
+		rt.refs++
 
 		return rt
 	}
@@ -362,6 +393,30 @@ func (s *Storage[K]) removeVersion(version string) error {
 	return nil
 }
 
+func (s *Storage[K]) storedBytesOverflow() bool {
+	if s.limit == 0 {
+		return false
+	}
+
+	total := atomic.LoadInt64(&s.bytes)
+	total = max(total, 0)
+
+	return uint64(total) > s.limit
+}
+
+func (s *Storage[K]) addStoredBytes(delta int64) {
+	if delta == 0 {
+		return
+	}
+
+	total := atomic.AddInt64(&s.bytes, delta)
+	if total >= 0 {
+		return
+	}
+
+	atomic.StoreInt64(&s.bytes, 0)
+}
+
 func (s *Storage[K]) restoreIndex() (err error) {
 	f, err := os.Open(filepath.Join(s.dir, indexFileName))
 	if err != nil {
@@ -371,6 +426,7 @@ func (s *Storage[K]) restoreIndex() (err error) {
 
 		return err
 	}
+
 	defer func() {
 		if clErr := f.Close(); clErr != nil && err == nil {
 			err = clErr
@@ -378,7 +434,25 @@ func (s *Storage[K]) restoreIndex() (err error) {
 	}()
 
 	_, err = s.index.Restore(f)
+	if err == nil {
+		s.recountStoredBytes()
+	}
+
 	return err
+}
+
+func (s *Storage[K]) recountStoredBytes() {
+	var total int64
+
+	_, _ = s.index.Walk(func(entry cache.EntryBy[K, storedEntry]) error {
+		if size := entry.Value().Meta.Size; size > 0 {
+			total += size
+		}
+
+		return nil
+	})
+
+	atomic.StoreInt64(&s.bytes, total)
 }
 
 func (s *Storage[K]) dumpIndex() (err error) {
@@ -388,6 +462,7 @@ func (s *Storage[K]) dumpIndex() (err error) {
 	}
 
 	tmpName := tmp.Name()
+
 	defer func() {
 		if tmp != nil {
 			if clErr := tmp.Close(); clErr != nil && err == nil {
@@ -408,6 +483,7 @@ func (s *Storage[K]) dumpIndex() (err error) {
 	if err := tmp.Close(); err != nil {
 		return err
 	}
+
 	tmp = nil
 
 	return os.Rename(tmpName, filepath.Join(s.dir, indexFileName))

--- a/filecache/storage_go1.18.go
+++ b/filecache/storage_go1.18.go
@@ -8,7 +8,6 @@ package filecache
 import (
 	"context"
 	"crypto/rand"
-	"encoding/gob"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -17,7 +16,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/bool64/cache"
@@ -30,60 +28,69 @@ const (
 	fileExt       = ".blob"
 )
 
+var (
+	_ cache.ReadWriterBy[string, blob.Entry]     = (*Storage[string])(nil)
+	_ cache.WriteAndReaderBy[string, blob.Entry] = (*Storage[string])(nil)
+)
+
 // Storage is a local filesystem-backed blob storage.
-type Storage struct {
+type Storage[K comparable] struct {
 	dir     string
 	dataDir string
 
-	index *cache.ShardedMapOf[blob.Entry]
+	index *cache.ShardedMapBy[K, storedEntry]
 
-	mu      sync.Mutex
-	runtime map[string]*runtimeFile
+	mu          sync.Mutex
+	openedFiles map[string]*openedFile
 
-	closeOnce sync.Once
+	openedWait sync.WaitGroup
+	closeOnce  sync.Once
 }
 
 type storedEntry struct {
-	storage *Storage
-	meta    blob.Meta
-	version string
+	Meta    blob.Meta
+	Version string
 }
 
-type persistedEntry struct {
-	Key      []byte
-	Meta     blob.Meta
-	Version  string
-	ExpireAt time.Time
-}
-
-type runtimeFile struct {
-	path string
+type openedFile struct {
 	refs int64
 	dead bool
 }
 
+type blobInstance struct {
+	open func() (io.ReadCloser, error)
+	meta blob.Meta
+}
+
+func (b *blobInstance) Meta() blob.Meta {
+	return b.meta
+}
+
+func (b *blobInstance) Open() (io.ReadCloser, error) {
+	return b.open()
+}
+
 // NewStorage creates a local filesystem-backed blob storage.
-func NewStorage(path string) (*Storage, error) {
-	s := &Storage{
-		dir:     path,
-		dataDir: filepath.Join(path, dataDirName),
-		runtime: make(map[string]*runtimeFile),
+func NewStorage[K comparable](path string) (*Storage[K], error) {
+	s := &Storage[K]{
+		dir:         path,
+		dataDir:     filepath.Join(path, dataDirName),
+		openedFiles: make(map[string]*openedFile),
 	}
 
 	if err := os.MkdirAll(s.dataDir, 0o750); err != nil {
 		return nil, err
 	}
 
-	s.index = cache.NewShardedMapOf[blob.Entry](cache.Config{
-		Name:               "filecache:" + filepath.Base(path),
-		ExpirationJitter:   -1,
-		EvictionStrategy:   cache.EvictMostExpired,
-		TimeToLive:         cache.UnlimitedTTL,
-		DeleteExpiredAfter: 24 * time.Hour,
-		OnDelete: func(_ []byte, value interface{}) {
-			if entry, ok := value.(blob.Entry); ok {
-				s.markDead(entry)
-			}
+	s.index = cache.NewShardedMapBy[K, storedEntry](cache.ConfigBy[K]{
+		Config: cache.Config{
+			Name:       "filecache:" + filepath.Base(path),
+			TimeToLive: cache.UnlimitedTTL,
+			OnDelete: func(_ []byte, value interface{}) {
+				if entry, ok := value.(storedEntry); ok {
+					s.markDead(entry.Version)
+				}
+			},
 		},
 	}.Use)
 
@@ -93,164 +100,159 @@ func NewStorage(path string) (*Storage, error) {
 		return nil, err
 	}
 
-	if err := s.reconcileFiles(); err != nil {
-		s.index = nil
-
-		return nil, err
-	}
-
 	return s, nil
 }
 
 // Read reads a blob entry by key.
-func (s *Storage) Read(ctx context.Context, key []byte) (blob.Entry, error) {
-	return s.index.Read(ctx, key)
+func (s *Storage[K]) Read(ctx context.Context, key K) (blob.Entry, error) {
+	v, err := s.index.Read(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+
+	b := blobInstance{
+		meta: v.Meta,
+		open: func() (io.ReadCloser, error) {
+			return s.openVersion(v.Version)
+		},
+	}
+
+	return &b, err
 }
 
 // Write materializes a blob entry into local storage and updates the index.
-func (s *Storage) Write(ctx context.Context, key []byte, entry blob.Entry) error {
+func (s *Storage[K]) Write(ctx context.Context, key K, entry blob.Entry) error {
 	_, err := s.WriteAndRead(ctx, key, entry)
 
 	return err
 }
 
 // WriteAndRead materializes a blob entry into local storage, updates the index, and returns the stored entry.
-func (s *Storage) WriteAndRead(ctx context.Context, key []byte, entry blob.Entry) (blob.Entry, error) {
+func (s *Storage[K]) WriteAndRead(ctx context.Context, key K, entry blob.Entry) (_ blob.Entry, err error) {
 	rc, err := entry.Open()
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if clErr := rc.Close(); clErr != nil && err == nil {
+			err = clErr
+		}
+	}()
 
 	version, err := newVersion()
 	if err != nil {
-		_ = rc.Close()
-
 		return nil, err
 	}
 
 	finalPath := s.pathForVersion(version)
 	if err := os.MkdirAll(filepath.Dir(finalPath), 0o750); err != nil {
-		_ = rc.Close()
-
 		return nil, err
 	}
 
 	tmp, err := os.CreateTemp(filepath.Dir(finalPath), version+".tmp-*")
 	if err != nil {
-		_ = rc.Close()
-
 		return nil, err
 	}
-
 	tmpName := tmp.Name()
-	cleanupTemp := func() {
+
+	defer func() {
+		if clErr := tmp.Close(); clErr != nil && err == nil {
+			err = clErr
+		}
 		_ = os.Remove(tmpName)
-	}
+	}()
 
 	if _, err := io.Copy(tmp, rc); err != nil {
-		_ = tmp.Close()
-		_ = rc.Close()
-
-		cleanupTemp()
-
-		return nil, err
-	}
-
-	if err := tmp.Close(); err != nil {
-		_ = rc.Close()
-
-		cleanupTemp()
-
 		return nil, err
 	}
 
 	if err := rc.Close(); err != nil {
-		cleanupTemp()
+		return nil, err
+	}
 
+	if err := tmp.Close(); err != nil {
 		return nil, err
 	}
 
 	if err := os.Rename(tmpName, finalPath); err != nil {
-		cleanupTemp()
-
 		return nil, err
 	}
 
-	newEntry := &storedEntry{
-		storage: s,
-		meta:    entry.Meta(),
-		version: version,
+	newEntry := storedEntry{
+		Meta:    entry.Meta(),
+		Version: version,
 	}
 
-	s.ensureRuntime(version, finalPath)
-
-	oldEntry, _ := s.currentEntry(ctx, key)
+	oldEntry, oldEntryExists := s.currentEntry(ctx, key)
 
 	if err := s.index.Write(ctx, key, newEntry); err != nil {
-		s.markDead(newEntry)
+		s.markDead(version)
 
 		return nil, err
 	}
 
-	if oldEntry != nil {
-		s.markDead(oldEntry)
+	if oldEntryExists {
+		s.markDead(oldEntry.Version)
 	}
 
-	return newEntry, nil
+	b := blobInstance{
+		meta: newEntry.Meta,
+		open: func() (io.ReadCloser, error) {
+			return s.openVersion(newEntry.Version)
+		},
+	}
+
+	return &b, nil
 }
 
 // Delete deletes a blob entry by key.
-func (s *Storage) Delete(ctx context.Context, key []byte) error {
-	return s.index.Delete(ctx, key)
+func (s *Storage[K]) Delete(ctx context.Context, key K) error {
+	v, ok := s.currentEntry(ctx, key)
+	err := s.index.Delete(ctx, key)
+
+	if ok && err == nil {
+		if !s.markDead(v.Version) {
+			_ = os.Remove(s.pathForVersion(v.Version))
+		}
+	}
+
+	return err
 }
 
 // Close dumps the in-memory index and stops background jobs.
-func (s *Storage) Close() error {
+func (s *Storage[K]) Close() error {
 	var err error
 
 	s.closeOnce.Do(func() {
 		err = s.dumpIndex()
-		if reconcileErr := s.reconcileFiles(); err == nil {
-			err = reconcileErr
-		}
-
 		s.index = nil
+		s.openedWait.Wait()
 	})
 
 	return err
 }
 
-func (e *storedEntry) Meta() blob.Meta {
-	return e.meta
-}
-
-func (e *storedEntry) Open() (io.ReadCloser, error) {
-	return e.storage.openVersion(e.version)
-}
-
-func (s *Storage) currentEntry(ctx context.Context, key []byte) (blob.Entry, bool) {
+func (s *Storage[K]) currentEntry(ctx context.Context, key K) (storedEntry, bool) {
 	entry, err := s.index.Read(ctx, key)
 	if err == nil {
 		return entry, true
 	}
 
-	var errExpired cache.ErrWithExpiredItemOf[blob.Entry]
+	var errExpired cache.ErrWithExpiredItemOf[storedEntry]
 	if errors.As(err, &errExpired) {
 		return errExpired.Value(), true
 	}
 
-	return nil, false
+	return storedEntry{}, false
 }
 
-func (s *Storage) openVersion(version string) (io.ReadCloser, error) {
-	path := s.pathForVersion(version)
-	rt := s.ensureRuntime(version, path)
-	atomic.AddInt64(&rt.refs, 1)
+func (s *Storage[K]) openVersion(version string) (io.ReadCloser, error) {
+	s.acquireVersion(version)
 
 	//nolint:gosec // Path is derived from internal versioned storage layout, not external input.
-	f, err := os.Open(path)
+	f, err := os.Open(s.pathForVersion(version))
 	if err != nil {
-		atomic.AddInt64(&rt.refs, -1)
+		s.releaseVersion(version)
 
 		return nil, err
 	}
@@ -263,84 +265,66 @@ func (s *Storage) openVersion(version string) (io.ReadCloser, error) {
 	}, nil
 }
 
-func (s *Storage) releaseVersion(version string) {
+func (s *Storage[K]) releaseVersion(version string) {
+	defer s.openedWait.Done()
+
 	s.mu.Lock()
-	rt := s.runtime[version]
+	rt := s.openedFiles[version]
+	if rt != nil {
+		rt.refs -= 1
+	}
 	s.mu.Unlock()
 
 	if rt == nil {
 		return
 	}
 
-	if atomic.AddInt64(&rt.refs, -1) == 0 {
+	if rt.refs == 0 && rt.dead {
+		_ = os.Remove(s.pathForVersion(version))
+
 		s.mu.Lock()
-		defer s.mu.Unlock()
-
-		rt = s.runtime[version]
-		if rt == nil || atomic.LoadInt64(&rt.refs) != 0 || !rt.dead {
-			return
-		}
-
-		_ = os.Remove(rt.path)
-
-		delete(s.runtime, version)
+		delete(s.openedFiles, version)
+		s.mu.Unlock()
 	}
 }
 
-func (s *Storage) ensureRuntime(version, path string) *runtimeFile {
+func (s *Storage[K]) acquireVersion(version string) *openedFile {
+	s.openedWait.Add(1)
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if rt, ok := s.runtime[version]; ok {
-		if rt.path == "" {
-			rt.path = path
-		}
+	rt := s.openedFiles[version]
+	if rt != nil {
+		rt.refs += 1
 
 		return rt
 	}
 
-	rt := &runtimeFile{path: path}
-	s.runtime[version] = rt
+	rt = &openedFile{
+		refs: 1,
+	}
+	s.openedFiles[version] = rt
 
 	return rt
 }
 
-func (s *Storage) markDead(entry blob.Entry) {
-	se, ok := entry.(*storedEntry)
-	if !ok || se == nil {
-		return
-	}
-
-	path := s.pathForVersion(se.version)
-
+func (s *Storage[K]) markDead(version string) bool {
 	s.mu.Lock()
-	rt := s.runtime[se.version]
+	defer s.mu.Unlock()
+
+	rt := s.openedFiles[version]
 
 	if rt == nil {
-		rt = &runtimeFile{path: path}
-		s.runtime[se.version] = rt
+		return false
 	}
 
 	rt.dead = true
-	refs := atomic.LoadInt64(&rt.refs)
-	s.mu.Unlock()
 
-	if refs == 0 {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-
-		rt = s.runtime[se.version]
-		if rt == nil || atomic.LoadInt64(&rt.refs) != 0 || !rt.dead {
-			return
-		}
-
-		_ = os.Remove(rt.path)
-
-		delete(s.runtime, se.version)
-	}
+	return true
 }
 
-func (s *Storage) restoreIndex() error {
+func (s *Storage[K]) restoreIndex() (err error) {
 	f, err := os.Open(filepath.Join(s.dir, indexFileName))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -349,68 +333,17 @@ func (s *Storage) restoreIndex() error {
 
 		return err
 	}
-	defer f.Close()
-
-	var entries []persistedEntry
-	if err := gob.NewDecoder(f).Decode(&entries); err != nil {
-		return err
-	}
-
-	now := time.Now()
-
-	for _, pe := range entries {
-		if _, err := os.Stat(s.pathForVersion(pe.Version)); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				continue
-			}
-
-			return err
+	defer func() {
+		if clErr := f.Close(); clErr != nil && err == nil {
+			err = clErr
 		}
+	}()
 
-		ctx := context.Background()
-		if pe.ExpireAt.UnixNano() != 0 {
-			ctx = cache.WithTTL(ctx, pe.ExpireAt.Sub(now), false)
-		}
-
-		entry := &storedEntry{
-			storage: s,
-			meta:    pe.Meta,
-			version: pe.Version,
-		}
-
-		s.ensureRuntime(pe.Version, s.pathForVersion(pe.Version))
-
-		if err := s.index.Write(ctx, pe.Key, entry); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	_, err = s.index.Restore(f)
+	return err
 }
 
-func (s *Storage) dumpIndex() error {
-	entries := make([]persistedEntry, 0)
-
-	_, err := s.index.Walk(func(entry cache.EntryOf[blob.Entry]) error {
-		se, ok := entry.Value().(*storedEntry)
-		if !ok || se == nil {
-			return fmt.Errorf("unexpected entry type %T", entry.Value())
-		}
-
-		key := append([]byte(nil), entry.Key()...)
-		entries = append(entries, persistedEntry{
-			Key:      key,
-			Meta:     se.meta,
-			Version:  se.version,
-			ExpireAt: entry.ExpireAt(),
-		})
-
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
+func (s *Storage[K]) dumpIndex() (err error) {
 	tmp, err := os.CreateTemp(s.dir, indexFileName+".tmp-*")
 	if err != nil {
 		return err
@@ -418,12 +351,13 @@ func (s *Storage) dumpIndex() error {
 
 	tmpName := tmp.Name()
 	defer func() {
-		_ = os.Remove(tmpName)
+		if rmErr := os.Remove(tmpName); rmErr != nil && err == nil {
+			err = rmErr
+		}
 	}()
 
-	if err := gob.NewEncoder(tmp).Encode(entries); err != nil {
-		_ = tmp.Close()
-
+	_, err = s.index.Dump(tmp)
+	if err != nil {
 		return err
 	}
 
@@ -434,64 +368,7 @@ func (s *Storage) dumpIndex() error {
 	return os.Rename(tmpName, filepath.Join(s.dir, indexFileName))
 }
 
-func (s *Storage) reconcileFiles() error {
-	referenced := make(map[string]struct{})
-	busyPaths := make(map[string]struct{})
-
-	_, err := s.index.Walk(func(entry cache.EntryOf[blob.Entry]) error {
-		se, ok := entry.Value().(*storedEntry)
-		if !ok || se == nil {
-			return fmt.Errorf("unexpected entry type %T", entry.Value())
-		}
-
-		referenced[s.pathForVersion(se.version)] = struct{}{}
-
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	s.mu.Lock()
-	for _, rt := range s.runtime {
-		if atomic.LoadInt64(&rt.refs) > 0 {
-			busyPaths[rt.path] = struct{}{}
-		}
-	}
-	s.mu.Unlock()
-
-	return filepath.Walk(s.dataDir, func(path string, info os.FileInfo, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-
-		if info.IsDir() {
-			return nil
-		}
-
-		if filepath.Ext(path) != fileExt && filepath.Ext(path) != ".tmp" {
-			return nil
-		}
-
-		if filepath.Ext(path) == ".tmp" {
-			//nolint:gosec // Reconciliation only removes files under application-owned cache storage.
-			return os.Remove(path)
-		}
-
-		if _, busy := busyPaths[path]; busy {
-			return nil
-		}
-
-		if _, ok := referenced[path]; ok {
-			return nil
-		}
-
-		//nolint:gosec // Reconciliation only removes files under application-owned cache storage.
-		return os.Remove(path)
-	})
-}
-
-func (s *Storage) pathForVersion(version string) string {
+func (s *Storage[K]) pathForVersion(version string) string {
 	path := s.dataDir
 	if len(version) >= 2 {
 		path = filepath.Join(path, version[:2])

--- a/filecache/storage_go1.18_test.go
+++ b/filecache/storage_go1.18_test.go
@@ -9,8 +9,11 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/bool64/cache"
 	"github.com/bool64/cache/blob"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -128,4 +131,54 @@ func TestStorage_customPathSplit(t *testing.T) {
 	expectedPath := filepath.Join(dir, dataDirName, entry.Version[:1], entry.Version+fileExt)
 	_, err = os.Stat(expectedPath)
 	require.NoError(t, err)
+}
+
+func TestStorage_storedBytesSoftLimit(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := NewStorage[string](dir, Config[string]{
+		IndexPolicy: cache.Policy{
+			TimeToLive:               cache.UnlimitedTTL,
+			DeleteExpiredJobInterval: time.Millisecond,
+			EvictFraction:            0.5,
+		},
+		RetentionPolicy: blob.RetentionPolicy{
+			StoredBytesSoftLimit: 10,
+		},
+	}.Use)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, s.Close())
+	}()
+
+	ctx := context.Background()
+	require.NoError(t, s.Write(ctx, "k1", blob.FromReader(bytes.NewBufferString("12345"), blob.Meta{})))
+	require.NoError(t, s.Write(ctx, "k2", blob.FromReader(bytes.NewBufferString("12345"), blob.Meta{})))
+	require.NoError(t, s.Write(ctx, "k3", blob.FromReader(bytes.NewBufferString("12345"), blob.Meta{})))
+
+	require.Eventually(t, func() bool {
+		total := atomic.LoadInt64(&s.bytes)
+		total = max(total, 0)
+
+		return s.index.Len() <= 2 && total <= 10
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestStorage_rewriteUpdatesStoredBytes(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := NewStorage[string](dir)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, s.Close())
+	}()
+
+	ctx := context.Background()
+	require.NoError(t, s.Write(ctx, "same", blob.FromReader(bytes.NewBufferString("12345"), blob.Meta{})))
+	assert.Equal(t, int64(5), atomic.LoadInt64(&s.bytes))
+
+	require.NoError(t, s.Write(ctx, "same", blob.FromReader(bytes.NewBufferString("12"), blob.Meta{})))
+	assert.Equal(t, int64(2), atomic.LoadInt64(&s.bytes))
 }

--- a/filecache/storage_go1.18_test.go
+++ b/filecache/storage_go1.18_test.go
@@ -159,7 +159,9 @@ func TestStorage_storedBytesSoftLimit(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		total := atomic.LoadInt64(&s.bytes)
-		total = max(total, 0)
+		if total < 0 {
+			total = 0
+		}
 
 		return s.index.Len() <= 2 && total <= 10
 	}, time.Second, 10*time.Millisecond)

--- a/filecache/storage_go1.18_test.go
+++ b/filecache/storage_go1.18_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/bool64/cache/blob"
@@ -18,23 +19,23 @@ import (
 func TestStorage_persistedIndex(t *testing.T) {
 	dir := t.TempDir()
 
-	s, err := NewStorage(dir)
+	s, err := NewStorage[string](dir)
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	require.NoError(t, s.Write(ctx, []byte("k1"), blob.FromReader(bytes.NewBufferString("value"), blob.Meta{
+	require.NoError(t, s.Write(ctx, "k1", blob.FromReader(bytes.NewBufferString("value"), blob.Meta{
 		Name: "a.txt",
 	})))
 	require.NoError(t, s.Close())
 
-	s, err = NewStorage(dir)
+	s, err = NewStorage[string](dir)
 	require.NoError(t, err)
 
 	defer func() {
 		require.NoError(t, s.Close())
 	}()
 
-	entry, err := s.Read(ctx, []byte("k1"))
+	entry, err := s.Read(ctx, "k1")
 	require.NoError(t, err)
 	assert.Equal(t, "a.txt", entry.Meta().Name)
 
@@ -50,7 +51,7 @@ func TestStorage_persistedIndex(t *testing.T) {
 func TestStorage_rewriteDeletesOldVersionAfterLastClose(t *testing.T) {
 	dir := t.TempDir()
 
-	s, err := NewStorage(dir)
+	s, err := NewStorage[string](dir)
 	require.NoError(t, err)
 
 	defer func() {
@@ -58,30 +59,18 @@ func TestStorage_rewriteDeletesOldVersionAfterLastClose(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	key := []byte("same")
+	key := "same"
 
 	require.NoError(t, s.Write(ctx, key, blob.FromReader(bytes.NewBufferString("v1"), blob.Meta{Name: "v1.txt"})))
 
 	entry, err := s.Read(ctx, key)
 	require.NoError(t, err)
 
-	oldStored, ok := entry.(*storedEntry)
-	require.True(t, ok)
-
-	oldPath := s.pathForVersion(oldStored.version)
-
 	rc, err := entry.Open()
 	require.NoError(t, err)
 
 	require.NoError(t, s.Write(ctx, key, blob.FromReader(bytes.NewBufferString("v2"), blob.Meta{Name: "v2.txt"})))
-
-	_, err = os.Stat(oldPath)
-	require.NoError(t, err)
-
 	require.NoError(t, rc.Close())
-
-	_, err = os.Stat(oldPath)
-	assert.ErrorIs(t, err, os.ErrNotExist)
 
 	newEntry, err := s.Read(ctx, key)
 	require.NoError(t, err)
@@ -98,7 +87,7 @@ func TestStorage_rewriteDeletesOldVersionAfterLastClose(t *testing.T) {
 func TestStorage_deleteRemovesFile(t *testing.T) {
 	dir := t.TempDir()
 
-	s, err := NewStorage(dir)
+	s, err := NewStorage[string](dir)
 	require.NoError(t, err)
 
 	defer func() {
@@ -106,19 +95,37 @@ func TestStorage_deleteRemovesFile(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	key := []byte("delete-me")
+	key := "delete-me"
 
 	require.NoError(t, s.Write(ctx, key, blob.FromReader(bytes.NewBufferString("gone"), blob.Meta{})))
 	entry, err := s.Read(ctx, key)
 	require.NoError(t, err)
 
-	se, ok := entry.(*storedEntry)
-	require.True(t, ok)
-
-	path := s.pathForVersion(se.version)
-
 	require.NoError(t, s.Delete(ctx, key))
 
-	_, err = os.Stat(path)
+	_, err = entry.Open()
 	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestStorage_customPathSplit(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := NewStorage[string](dir, Config[string]{
+		SplitPath: PrefixSplit(1),
+	}.Use)
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, s.Close())
+	}()
+
+	ctx := context.Background()
+	require.NoError(t, s.Write(ctx, "k1", blob.FromReader(bytes.NewBufferString("value"), blob.Meta{})))
+
+	entry, ok := s.currentEntry(ctx, "k1")
+	require.True(t, ok)
+
+	expectedPath := filepath.Join(dir, dataDirName, entry.Version[:1], entry.Version+fileExt)
+	_, err = os.Stat(expectedPath)
+	require.NoError(t, err)
 }

--- a/key_sharder_benchmark_go1.18_test.go
+++ b/key_sharder_benchmark_go1.18_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Benchmark_ShardFunc_int_default(b *testing.B) {
-	benchShardFuncInt(b, resolveShardFunc(ConfigBy[int]{}))
+	benchShardFuncInt(b, resolveShardFunc(ConfigBy[int, int]{}))
 }
 
 func Benchmark_ShardFunc_int_specialized(b *testing.B) {
@@ -20,7 +20,7 @@ func Benchmark_ShardFunc_int_specialized(b *testing.B) {
 }
 
 func Benchmark_ShardFunc_int_customConfig(b *testing.B) {
-	benchShardFuncInt(b, resolveShardFunc(ConfigBy[int]{
+	benchShardFuncInt(b, resolveShardFunc(ConfigBy[int, int]{
 		ShardFunc: func(key int) uint64 {
 			return mixInt64(int64(key))
 		},
@@ -61,7 +61,7 @@ func benchShardFuncInt(b *testing.B, shard func(int) uint64) {
 func benchShardedMapByIntConcurrent(b *testing.B, shard func(int) uint64) {
 	b.Helper()
 
-	c := NewShardedMapBy[int, int](func(cfg *ConfigBy[int]) {
+	c := NewShardedMapBy[int, int](func(cfg *ConfigBy[int, int]) {
 		cfg.ShardFunc = shard
 	})
 	ctx := context.Background()

--- a/key_sharder_go1.18.go
+++ b/key_sharder_go1.18.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 )
 
-func resolveShardFunc[K comparable](cfg ConfigBy[K]) func(K) uint64 {
+func resolveShardFunc[K comparable, V any](cfg ConfigBy[K, V]) func(K) uint64 {
 	if cfg.ShardFunc != nil {
 		return cfg.ShardFunc
 	}

--- a/sharded_map.go
+++ b/sharded_map.go
@@ -37,7 +37,8 @@ type shardedMap struct {
 
 	hashedBuckets [shards]hashedBucket
 
-	t *Trait
+	onDelete func([]byte, interface{})
+	t        *Trait
 }
 
 // NewShardedMap creates an instance of in-memory cache with optional configuration.
@@ -56,13 +57,15 @@ func NewShardedMap(options ...func(cfg *Config)) *ShardedMap {
 		option(&cfg)
 	}
 
+	c.onDelete = cfg.OnDelete
+
 	evict := c.evictMostExpired
 
 	if cfg.EvictionStrategy != EvictMostExpired {
 		evict = c.evictLeastCounter
 	}
 
-	c.t = NewTrait(cfg, func(t *Trait) {
+	c.t = NewTrait(cfg.Policy, func(t *Trait) {
 		t.DeleteExpired = c.deleteExpired
 		t.Len = c.Len
 		t.Evict = evict
@@ -190,7 +193,7 @@ func (c *shardedMap) ExpireAll(ctx context.Context) {
 func (c *shardedMap) DeleteAll(ctx context.Context) {
 	now := time.Now()
 	cnt := 0
-	collectRemoved := c.t.Config.OnDelete != nil
+	collectRemoved := c.onDelete != nil
 
 	var removed []TraitEntry
 
@@ -220,7 +223,7 @@ func (c *shardedMap) DeleteAll(ctx context.Context) {
 
 func (c *shardedMap) deleteExpired(before time.Time) {
 	beforeTS := ts(before)
-	collectRemoved := c.t.Config.OnDelete != nil
+	collectRemoved := c.onDelete != nil
 
 	var removed []TraitEntry
 
@@ -400,17 +403,17 @@ func (c *shardedMap) evictLeast(evictFraction float64, val func(i *TraitEntry) i
 }
 
 func (c *shardedMap) notifyDeletedEntries(entries []TraitEntry) {
-	if c.t.Config.OnDelete == nil {
+	if c.onDelete == nil {
 		return
 	}
 
 	for _, entry := range entries {
-		c.t.Config.OnDelete(entry.K, entry.V)
+		c.onDelete(entry.K, entry.V)
 	}
 }
 
 func (c *shardedMap) notifyDeletedEntry(entry TraitEntry) {
-	if c.t.Config.OnDelete != nil {
-		c.t.Config.OnDelete(entry.K, entry.V)
+	if c.onDelete != nil {
+		c.onDelete(entry.K, entry.V)
 	}
 }

--- a/sharded_map_by_go1.18.go
+++ b/sharded_map_by_go1.18.go
@@ -5,6 +5,9 @@ package cache
 
 import (
 	"context"
+	"encoding/gob"
+	"errors"
+	"io"
 	"runtime"
 	"sort"
 	"sync"
@@ -15,6 +18,8 @@ import (
 var (
 	_ ReadWriterBy[string, any] = &shardedMapBy[string, any]{}
 	_ WalkerBy[string, any]     = &shardedMapBy[string, any]{}
+	_ Dumper                    = &ShardedMapBy[string, any]{}
+	_ Restorer                  = &ShardedMapBy[string, any]{}
 )
 
 // ShardedMapBy is an in-memory cache backend with typed keys. Please use NewShardedMapBy to create it.
@@ -302,4 +307,51 @@ func (c *shardedMapBy[K, V]) evictLeast(evictFraction float64, val func(i *Trait
 	}
 
 	return evictItems
+}
+
+// Dump saves cached entries and returns a number of processed entries.
+//
+// Dump uses encoding/gob to serialize cache entries, therefore it is necessary to
+// register cached types in advance with cache.GobRegister.
+func (c *ShardedMapBy[K, V]) Dump(w io.Writer) (int, error) {
+	encoder := gob.NewEncoder(w)
+
+	return c.Walk(func(e EntryBy[K, V]) error {
+		return encoder.Encode(e)
+	})
+}
+
+// Restore loads cached entries and returns number of processed entries.
+//
+// Restore uses encoding/gob to unserialize cache entries, therefore it is necessary to
+// register cached types in advance with cache.GobRegister.
+func (c *ShardedMapBy[K, V]) Restore(r io.Reader) (int, error) {
+	var (
+		decoder = gob.NewDecoder(r)
+		n       = 0
+	)
+
+	for {
+		var e TraitEntryBy[K, V]
+
+		err := decoder.Decode(&e)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return n, err
+		}
+
+		h := c.shard(e.K)
+		b := &c.hashedBuckets[h%shards]
+
+		b.Lock()
+		b.data[e.K] = &e
+		b.Unlock()
+
+		n++
+	}
+
+	return n, nil
 }

--- a/sharded_map_by_go1.18.go
+++ b/sharded_map_by_go1.18.go
@@ -144,11 +144,11 @@ func (c *shardedMapBy[K, V]) Write(ctx context.Context, key K, v V) error {
 
 // Delete removes value by the key.
 func (c *shardedMapBy[K, V]) Delete(ctx context.Context, key K) error {
-	h := c.shard(key)
-	b := &c.hashedBuckets[h%shards]
+	b := &c.hashedBuckets[c.shard(key)%shards]
 
 	b.Lock()
 	removed, found := b.data[key]
+
 	if !found {
 		b.Unlock()
 

--- a/sharded_map_by_go1.18.go
+++ b/sharded_map_by_go1.18.go
@@ -39,7 +39,8 @@ type evictLeastEntryBy[K comparable] struct {
 }
 
 type shardedMapBy[K comparable, V any] struct {
-	shard func(K) uint64
+	shard    func(K) uint64
+	onDelete func(K, V)
 
 	hashedBuckets [shards]keyedBucketBy[K, V]
 
@@ -47,7 +48,7 @@ type shardedMapBy[K comparable, V any] struct {
 }
 
 // NewShardedMapBy creates an instance of in-memory cache with typed keys and optional configuration.
-func NewShardedMapBy[K comparable, V any](options ...func(cfg *ConfigBy[K])) *ShardedMapBy[K, V] {
+func NewShardedMapBy[K comparable, V any](options ...func(cfg *ConfigBy[K, V])) *ShardedMapBy[K, V] {
 	c := &shardedMapBy[K, V]{}
 	C := &ShardedMapBy[K, V]{
 		shardedMapBy: c,
@@ -57,12 +58,13 @@ func NewShardedMapBy[K comparable, V any](options ...func(cfg *ConfigBy[K])) *Sh
 		c.hashedBuckets[i].data = make(map[K]*TraitEntryBy[K, V])
 	}
 
-	cfg := ConfigBy[K]{}
+	cfg := ConfigBy[K, V]{}
 	for _, option := range options {
 		option(&cfg)
 	}
 
 	c.shard = resolveShardFunc(cfg)
+	c.onDelete = cfg.OnDeleteBy
 
 	evict := c.evictMostExpired
 
@@ -70,7 +72,7 @@ func NewShardedMapBy[K comparable, V any](options ...func(cfg *ConfigBy[K])) *Sh
 		evict = c.evictLeastCounter
 	}
 
-	c.t = NewTraitBy[K, V](cfg.Config, func(t *Trait) {
+	c.t = NewTraitBy[K, V](cfg.Policy, func(t *Trait) {
 		t.DeleteExpired = c.deleteExpired
 		t.Len = c.Len
 		t.Evict = evict
@@ -146,13 +148,17 @@ func (c *shardedMapBy[K, V]) Delete(ctx context.Context, key K) error {
 	b := &c.hashedBuckets[h%shards]
 
 	b.Lock()
-	defer b.Unlock()
+	removed, found := b.data[key]
+	if !found {
+		b.Unlock()
 
-	if _, found := b.data[key]; !found {
 		return ErrNotFound
 	}
 
 	delete(b.data, key)
+	b.Unlock()
+
+	c.notifyDeletedEntry(*removed)
 
 	c.t.NotifyDeleted(ctx, key)
 
@@ -184,12 +190,23 @@ func (c *shardedMapBy[K, V]) ExpireAll(ctx context.Context) {
 func (c *shardedMapBy[K, V]) DeleteAll(ctx context.Context) {
 	start := time.Now()
 	cnt := 0
+	collectRemoved := c.onDelete != nil
+
+	var removed []TraitEntryBy[K, V]
+
+	if collectRemoved {
+		removed = make([]TraitEntryBy[K, V], 0)
+	}
 
 	for i := range c.hashedBuckets {
 		b := &c.hashedBuckets[i]
 
 		b.Lock()
-		for k := range c.hashedBuckets[i].data {
+		for k, v := range c.hashedBuckets[i].data {
+			if collectRemoved {
+				removed = append(removed, *v)
+			}
+
 			delete(b.data, k)
 
 			cnt++
@@ -197,11 +214,19 @@ func (c *shardedMapBy[K, V]) DeleteAll(ctx context.Context) {
 		b.Unlock()
 	}
 
+	c.notifyDeletedEntries(removed)
 	c.t.NotifyDeletedAll(ctx, start, cnt)
 }
 
 func (c *shardedMapBy[K, V]) deleteExpired(before time.Time) {
 	beforeTS := ts(before)
+	collectRemoved := c.onDelete != nil
+
+	var removed []TraitEntryBy[K, V]
+
+	if collectRemoved {
+		removed = make([]TraitEntryBy[K, V], 0)
+	}
 
 	for i := range c.hashedBuckets {
 		b := &c.hashedBuckets[i]
@@ -209,11 +234,17 @@ func (c *shardedMapBy[K, V]) deleteExpired(before time.Time) {
 		b.Lock()
 		for k, v := range b.data {
 			if v.E < beforeTS {
+				if collectRemoved {
+					removed = append(removed, *v)
+				}
+
 				delete(b.data, k)
 			}
 		}
 		b.Unlock()
 	}
+
+	c.notifyDeletedEntries(removed)
 }
 
 // Len returns number of elements in cache.
@@ -302,11 +333,31 @@ func (c *shardedMapBy[K, V]) evictLeast(evictFraction float64, val func(i *Trait
 		b := &c.hashedBuckets[e.shard]
 
 		b.Lock()
+		if removed, found := b.data[e.key]; found {
+			c.notifyDeletedEntry(*removed)
+		}
+
 		delete(b.data, e.key)
 		b.Unlock()
 	}
 
 	return evictItems
+}
+
+func (c *shardedMapBy[K, V]) notifyDeletedEntries(entries []TraitEntryBy[K, V]) {
+	if c.onDelete == nil {
+		return
+	}
+
+	for _, entry := range entries {
+		c.onDelete(entry.K, entry.V)
+	}
+}
+
+func (c *shardedMapBy[K, V]) notifyDeletedEntry(entry TraitEntryBy[K, V]) {
+	if c.onDelete != nil {
+		c.onDelete(entry.K, entry.V)
+	}
 }
 
 // Dump saves cached entries and returns a number of processed entries.

--- a/sharded_map_go1.18.go
+++ b/sharded_map_go1.18.go
@@ -39,11 +39,12 @@ type shardedMapOf[V any] struct {
 
 	hashedBuckets [shards]hashedBucketOf[V]
 
-	t *TraitOf[V]
+	onDelete func([]byte, V)
+	t        *TraitOf[V]
 }
 
 // NewShardedMapOf creates an instance of in-memory cache with optional configuration.
-func NewShardedMapOf[V any](options ...func(cfg *Config)) *ShardedMapOf[V] {
+func NewShardedMapOf[V any](options ...func(cfg *ConfigOf[V])) *ShardedMapOf[V] {
 	c := &shardedMapOf[V]{}
 	C := &ShardedMapOf[V]{
 		shardedMapOf: c,
@@ -53,10 +54,12 @@ func NewShardedMapOf[V any](options ...func(cfg *Config)) *ShardedMapOf[V] {
 		c.hashedBuckets[i].data = make(map[uint64]*TraitEntryOf[V])
 	}
 
-	cfg := Config{}
+	cfg := ConfigOf[V]{}
 	for _, option := range options {
 		option(&cfg)
 	}
+
+	c.onDelete = cfg.OnDelete
 
 	evict := c.evictMostExpired
 
@@ -64,7 +67,7 @@ func NewShardedMapOf[V any](options ...func(cfg *Config)) *ShardedMapOf[V] {
 		evict = c.evictLeastCounter
 	}
 
-	c.t = NewTraitOf[V](cfg, func(t *Trait) {
+	c.t = NewTraitOf[V](cfg.Policy, func(t *Trait) {
 		t.DeleteExpired = c.deleteExpired
 		t.Len = c.Len
 		t.Evict = evict
@@ -196,7 +199,7 @@ func (c *shardedMapOf[V]) ExpireAll(ctx context.Context) {
 func (c *shardedMapOf[V]) DeleteAll(ctx context.Context) {
 	start := time.Now()
 	cnt := 0
-	collectRemoved := c.t.Config.OnDelete != nil
+	collectRemoved := c.onDelete != nil
 
 	var removed []TraitEntryOf[V]
 
@@ -226,7 +229,7 @@ func (c *shardedMapOf[V]) DeleteAll(ctx context.Context) {
 
 func (c *shardedMapOf[V]) deleteExpired(before time.Time) {
 	beforeTS := ts(before)
-	collectRemoved := c.t.Config.OnDelete != nil
+	collectRemoved := c.onDelete != nil
 
 	var removed []TraitEntryOf[V]
 
@@ -452,17 +455,17 @@ func (c *shardedMapOf[V]) evictLeast(evictFraction float64, val func(i *TraitEnt
 }
 
 func (c *shardedMapOf[V]) notifyDeletedEntries(entries []TraitEntryOf[V]) {
-	if c.t.Config.OnDelete == nil {
+	if c.onDelete == nil {
 		return
 	}
 
 	for _, entry := range entries {
-		c.t.Config.OnDelete(entry.K, entry.V)
+		c.onDelete(entry.K, entry.V)
 	}
 }
 
 func (c *shardedMapOf[V]) notifyDeletedEntry(entry TraitEntryOf[V]) {
-	if c.t.Config.OnDelete != nil {
-		c.t.Config.OnDelete(entry.K, entry.V)
+	if c.onDelete != nil {
+		c.onDelete(entry.K, entry.V)
 	}
 }

--- a/sharded_map_go1.18_test.go
+++ b/sharded_map_go1.18_test.go
@@ -21,7 +21,7 @@ func TestNewShardedMapOf(t *testing.T) {
 	st := stats.TrackerMock{}
 
 	func() {
-		c := cache.NewShardedMapOf[string](func(config *cache.Config) {
+		c := cache.NewShardedMapOf[string](func(config *cache.ConfigOf[string]) {
 			config.Logger = &logger
 			config.Stats = &st
 			config.Name = "test"
@@ -113,7 +113,7 @@ func TestNewShardedMapOf_Load_Store(t *testing.T) {
 	logger := ctxd.LoggerMock{}
 	st := stats.TrackerMock{}
 
-	c := cache.NewShardedMapOf[string](func(config *cache.Config) {
+	c := cache.NewShardedMapOf[string](func(config *cache.ConfigOf[string]) {
 		config.Logger = &logger
 		config.Stats = &st
 		config.Name = "test"

--- a/sync_map.go
+++ b/sync_map.go
@@ -28,7 +28,8 @@ type syncMap struct {
 
 	data sync.Map
 
-	t *Trait
+	onDelete func([]byte, interface{})
+	t        *Trait
 }
 
 // NewSyncMap creates an instance of in-memory cache with optional configuration.
@@ -43,13 +44,15 @@ func NewSyncMap(options ...func(cfg *Config)) *SyncMap {
 		option(&cfg)
 	}
 
+	c.onDelete = cfg.OnDelete
+
 	evict := c.evictMostExpired
 
 	if cfg.EvictionStrategy != EvictMostExpired {
 		evict = c.evictLeastCounter
 	}
 
-	c.t = NewTrait(cfg, func(t *Trait) {
+	c.t = NewTrait(cfg.Policy, func(t *Trait) {
 		t.DeleteExpired = c.deleteExpired
 		t.Len = c.Len
 		t.Evict = evict
@@ -93,9 +96,9 @@ func (c *syncMap) Write(ctx context.Context, k []byte, v interface{}) error {
 
 // Delete removes values by the key.
 func (c *syncMap) Delete(ctx context.Context, key []byte) error {
-	if value, found := c.data.LoadAndDelete(string(key)); found && c.t.Config.OnDelete != nil {
+	if value, found := c.data.LoadAndDelete(string(key)); found && c.onDelete != nil {
 		entry := value.(*TraitEntry)
-		c.t.Config.OnDelete(entry.K, entry.V)
+		c.onDelete(entry.K, entry.V)
 	}
 
 	c.t.NotifyDeleted(ctx, key)
@@ -125,7 +128,7 @@ func (c *syncMap) ExpireAll(ctx context.Context) {
 func (c *syncMap) DeleteAll(ctx context.Context) {
 	start := time.Now()
 	cnt := 0
-	collectRemoved := c.t.Config.OnDelete != nil
+	collectRemoved := c.onDelete != nil
 
 	var removed []TraitEntry
 
@@ -146,8 +149,8 @@ func (c *syncMap) DeleteAll(ctx context.Context) {
 	})
 
 	for _, entry := range removed {
-		if c.t.Config.OnDelete != nil {
-			c.t.Config.OnDelete(entry.K, entry.V)
+		if c.onDelete != nil {
+			c.onDelete(entry.K, entry.V)
 		}
 	}
 
@@ -162,8 +165,8 @@ func (c *syncMap) deleteExpired(before time.Time) {
 		if cacheEntry.E < beforeTS {
 			c.data.Delete(key)
 
-			if c.t.Config.OnDelete != nil {
-				c.t.Config.OnDelete(cacheEntry.K, cacheEntry.V)
+			if c.onDelete != nil {
+				c.onDelete(cacheEntry.K, cacheEntry.V)
 			}
 		}
 

--- a/sync_map_by_go1.18.go
+++ b/sync_map_by_go1.18.go
@@ -25,7 +25,8 @@ type SyncMapBy[K comparable, V any] struct {
 type syncMapBy[K comparable, V any] struct {
 	data sync.Map
 
-	t *TraitBy[K, V]
+	onDelete func(K, V)
+	t        *TraitBy[K, V]
 }
 
 type syncMapEvictEntryBy[K comparable] struct {
@@ -34,16 +35,18 @@ type syncMapEvictEntryBy[K comparable] struct {
 }
 
 // NewSyncMapBy creates an instance of in-memory cache with typed keys and optional configuration.
-func NewSyncMapBy[K comparable, V any](options ...func(cfg *Config)) *SyncMapBy[K, V] {
+func NewSyncMapBy[K comparable, V any](options ...func(cfg *ConfigBy[K, V])) *SyncMapBy[K, V] {
 	c := &syncMapBy[K, V]{}
 	C := &SyncMapBy[K, V]{
 		syncMapBy: c,
 	}
 
-	cfg := Config{}
+	cfg := ConfigBy[K, V]{}
 	for _, option := range options {
 		option(&cfg)
 	}
+
+	c.onDelete = cfg.OnDeleteBy
 
 	evict := c.evictMostExpired
 
@@ -51,7 +54,7 @@ func NewSyncMapBy[K comparable, V any](options ...func(cfg *Config)) *SyncMapBy[
 		evict = c.evictLeastCounter
 	}
 
-	c.t = NewTraitBy[K, V](cfg, func(t *Trait) {
+	c.t = NewTraitBy[K, V](cfg.Policy, func(t *Trait) {
 		t.DeleteExpired = c.deleteExpired
 		t.Len = c.Len
 		t.Evict = evict
@@ -110,12 +113,13 @@ func (c *syncMapBy[K, V]) Write(ctx context.Context, key K, v V) error {
 
 // Delete removes values by the key.
 func (c *syncMapBy[K, V]) Delete(ctx context.Context, key K) error {
-	_, found := c.data.Load(key)
+	value, found := c.data.Load(key)
 	if !found {
 		return ErrNotFound
 	}
 
 	c.data.Delete(key)
+	c.notifyDeletedEntry(*value.(*TraitEntryBy[K, V]))
 
 	c.t.NotifyDeleted(ctx, key)
 
@@ -145,8 +149,18 @@ func (c *syncMapBy[K, V]) ExpireAll(ctx context.Context) {
 func (c *syncMapBy[K, V]) DeleteAll(ctx context.Context) {
 	start := time.Now()
 	cnt := 0
+	collectRemoved := c.onDelete != nil
 
-	c.data.Range(func(key, _ interface{}) bool {
+	var removed []TraitEntryBy[K, V]
+	if collectRemoved {
+		removed = make([]TraitEntryBy[K, V], 0)
+	}
+
+	c.data.Range(func(key, value interface{}) bool {
+		if collectRemoved {
+			removed = append(removed, *value.(*TraitEntryBy[K, V]))
+		}
+
 		c.data.Delete(key)
 
 		cnt++
@@ -154,20 +168,33 @@ func (c *syncMapBy[K, V]) DeleteAll(ctx context.Context) {
 		return true
 	})
 
+	c.notifyDeletedEntries(removed)
 	c.t.NotifyDeletedAll(ctx, start, cnt)
 }
 
 func (c *syncMapBy[K, V]) deleteExpired(before time.Time) {
 	beforeTS := ts(before)
+	collectRemoved := c.onDelete != nil
+
+	var removed []TraitEntryBy[K, V]
+	if collectRemoved {
+		removed = make([]TraitEntryBy[K, V], 0)
+	}
 
 	c.data.Range(func(key, value interface{}) bool {
 		cacheEntry := value.(*TraitEntryBy[K, V])
 		if cacheEntry.E < beforeTS {
+			if collectRemoved {
+				removed = append(removed, *cacheEntry)
+			}
+
 			c.data.Delete(key)
 		}
 
 		return true
 	})
+
+	c.notifyDeletedEntries(removed)
 }
 
 // Len returns number of elements including expired.
@@ -235,8 +262,28 @@ func (c *syncMapBy[K, V]) evictLeast(evictFraction float64, val func(i *TraitEnt
 	evictItems := int(float64(len(entries)) * evictFraction)
 
 	for i := 0; i < evictItems; i++ {
+		if value, ok := c.data.Load(entries[i].key); ok {
+			c.notifyDeletedEntry(*value.(*TraitEntryBy[K, V]))
+		}
+
 		c.data.Delete(entries[i].key)
 	}
 
 	return evictItems
+}
+
+func (c *syncMapBy[K, V]) notifyDeletedEntries(entries []TraitEntryBy[K, V]) {
+	if c.onDelete == nil {
+		return
+	}
+
+	for _, entry := range entries {
+		c.onDelete(entry.K, entry.V)
+	}
+}
+
+func (c *syncMapBy[K, V]) notifyDeletedEntry(entry TraitEntryBy[K, V]) {
+	if c.onDelete != nil {
+		c.onDelete(entry.K, entry.V)
+	}
 }

--- a/trait.go
+++ b/trait.go
@@ -149,7 +149,7 @@ type Trait struct {
 	Len           func() int
 	Evict         func(fraction float64) int
 
-	Config Config
+	Config Policy
 	Stat   StatsTracker
 	Log    logTrait
 
@@ -157,7 +157,7 @@ type Trait struct {
 }
 
 // NewTrait instantiates new Trait.
-func NewTrait(config Config, options ...func(t *Trait)) *Trait {
+func NewTrait(config Policy, options ...func(t *Trait)) *Trait {
 	if config.DeleteExpiredAfter == 0 {
 		config.DeleteExpiredAfter = 24 * time.Hour
 	}

--- a/trait_by_go1.18.go
+++ b/trait_by_go1.18.go
@@ -15,7 +15,7 @@ type TraitBy[K comparable, V any] struct {
 }
 
 // NewTraitBy instantiates new TraitBy.
-func NewTraitBy[K comparable, V any](config Config, options ...func(t *Trait)) *TraitBy[K, V] {
+func NewTraitBy[K comparable, V any](config Policy, options ...func(t *Trait)) *TraitBy[K, V] {
 	t := &TraitBy[K, V]{}
 
 	t.Trait = *NewTrait(config, options...)

--- a/trait_go1.18.go
+++ b/trait_go1.18.go
@@ -16,7 +16,7 @@ type TraitOf[V any] struct {
 }
 
 // NewTraitOf instantiates new TraitOf.
-func NewTraitOf[V any](config Config, options ...func(t *Trait)) *TraitOf[V] {
+func NewTraitOf[V any](config Policy, options ...func(t *Trait)) *TraitOf[V] {
 	t := &TraitOf[V]{}
 
 	t.Trait = *NewTrait(config, options...)


### PR DESCRIPTION
## Summary

This PR continues the generic-key and blob-cache work with three main themes:

- redesign cache configs into backend-specific families built on shared `cache.Policy`
- finish `ShardedMapBy` parity for dump/restore and typed delete hooks
- rework `filecache` around generic keys, explicit filecache config, and blob-retention limits

It is a breaking API change.

## Main Changes

### 1. Config redesign

Shared cache settings were moved into:

```go
type cache.Policy struct { ... }
```

and the backend configs now mirror backend families:

- `cache.Config` for `[]byte -> any`
- `cache.ConfigOf[V]` for `[]byte -> V`
- `cache.ConfigBy[K, V]` for `K -> V`

Added helpers:

- `cache.WithPolicy(...)`
- `cache.WithPolicyOf[V](...)`
- `cache.WithPolicyBy[K, V](...)`

`ConfigBy` is now fully typed and includes:

```go
OnDeleteBy func(key K, value V)
```

This replaces the misleading reuse of byte-keyed delete hooks for typed-key caches.

Related fallout was updated across:

- `ShardedMap*`
- `SyncMap*`
- `Failover*`
- examples, tests, and benchmarks

### 2. `ShardedMapBy` parity and fixes

`ShardedMapBy` now supports:

- `Dump`
- `Restore`

and restore uses the cache’s actual shard function instead of hardcoding hash routing. This fixes restore correctness for custom sharders.

`ShardedMapBy` now also invokes `OnDeleteBy` for:

- `Delete`
- `DeleteAll`
- expiration cleanup
- eviction

Tests were added for:

- typed delete hook invocation
- dump/restore with a custom sharder

### 3. `filecache` moved to generic keys

`filecache.Storage` is now generic:

```go
filecache.NewStorage[K comparable](...)
```

and its internal index now uses:

```go
cache.ShardedMapBy[K, storedEntry]
```

instead of a byte-keyed typed map.

### 4. New filecache config

Added:

```go
type filecache.Config[K comparable] struct {
    IndexPolicy cache.Policy
    blob.RetentionPolicy
    IndexShardFunc func(K) uint64
    SplitPath func(version string) []string
}
```

This adds explicit control over:

- index cache policy
- index shard function
- blob retention settings
- on-disk blob directory splitting

Also added:

```go
filecache.PrefixSplit(...)
```

for configurable version path layouts.

### 5. Blob retention policy

Added:

```go
type blob.RetentionPolicy struct {
    StoredBytesSoftLimit uint64
}
```

`filecache.Config` embeds this so blob-specific storage pressure stays outside shared `cache.Policy`.

### 6. File deletion and lifecycle fixes in `filecache`

Blob cleanup is now owned by index removal via `OnDeleteBy`:

- if a blob version is not open, it is removed immediately
- if it is open, it is marked dead and removed by the last reader `Close()`

This removes the previous split responsibility between cache deletion callbacks and `Storage.Delete()`.

Additional cleanup/fixups:

- `Storage.Delete()` now delegates to `index.Delete()`
- last-reader `Close()` returns deferred delete failures
- temp file cleanup and remove errors are surfaced more consistently
- overwrite cleanup logs failures instead of silently dropping them
- delete races around stale pre-read state were removed

### 7. Stored-bytes eviction trigger for `filecache`

`filecache` now supports eviction based on total stored blob bytes through `blob.RetentionPolicy.StoredBytesSoftLimit`.

Implementation details:

- maintained with an atomic counter
- updated on write, overwrite, delete, and restore
- checked in O(1) through the index backend’s `EvictionNeeded`

This avoids walking the full index on every eviction check.

## Verification

Validated with:

```bash
GOCACHE=/tmp/gocache go test ./... -run '^$'
GOCACHE=/tmp/gocache go test ./... -run '^Test'
GOCACHE=/tmp/gocache GOPATH=/tmp/gopath GOMODCACHE=/tmp/gomodcache GOLANGCI_LINT_CACHE=/tmp/golangci-lint golangci-lint-v2.11.3 run ./...
```

Notes:

- unit tests pass
- lint passes
- full `go test ./...` still hits the known sandbox restriction around an `httptest` example binding a local port

## Breaking Changes

- shared cache settings moved from `cache.Config` into `cache.Policy`
- `cache.ConfigOf[V]` was introduced for typed `[]byte` keys
- `cache.ConfigBy` changed from `ConfigBy[K]` to `ConfigBy[K, V]`
- `FailoverOf.BackendConfig` now uses `cache.ConfigOf[V]`
- `FailoverBy.BackendConfig` now uses `cache.ConfigBy[K, V]`
- `filecache.NewStorage` is now generic and takes variadic config options
